### PR TITLE
Support for long kernel command line

### DIFF
--- a/boot/setup16.asm
+++ b/boot/setup16.asm
@@ -32,6 +32,7 @@
 #include <hal/asm/boot.h>
 #include <hal/asm/descriptors.h>
 #include <hal/asm/pic8259.h>
+#include <asm/cmdline.h>
 
 %define CODE_SEG        1
 %define DATA_SEG        2
@@ -62,7 +63,7 @@ signature:          dw BOOT_MAGIC
     jmp short start
 
 header:             db "HdrS"
-version:            dw 0x0204
+version:            dw 0x0206
 realmode_swtch:     dd 0
 start_sys:          dw 0x1000
 kernel_version:     dw str_version
@@ -78,6 +79,11 @@ pad1:               dw 0
 cmd_line_ptr:       dd 0
 initrd_addr_max:
 ramdisk_max:        dd BOOT_RAMDISK_LIMIT - 1
+kernel_alignment:   dd 0    ; Not relevant because kernel is not relocatable...
+relocatable_kernel: db 0    ; ... as indicated here
+min_alignment:      db 0    ; not relevant, protocol 2.10+
+xloadflags:         dw 0    ; not relevant, protocol 2.12+
+cmdline_size:       dd CMDLINE_MAX_VALID_LENGTH
 
 start:
     ; Setup the segment registers

--- a/boot/setup32.asm
+++ b/boot/setup32.asm
@@ -385,17 +385,20 @@ copy_cmdline:
     mov ecx, CMDLINE_MAX_PARSE_LENGTH
 .copy:
     lodsb                           ; load next character
+    stosb                           ; store character in destination
 
     dec ecx                         ; decrement max length counter
-    jnz .continue_copy              ; if we reached maximum length...
-    xor al, al                      ; ... NUL terminate string and stop
+    jz .too_long                    ; check if maximum length was reached
 
-.continue_copy
-    stosb                           ; store character in destination
     or al, al                       ; if character is not terminating NUL...
     jnz .copy                       ; ... continue with next character
 
 .skip:
+    ret
+
+.too_long:
+    mov al, 0                       ; NUL terminate cropped command line
+    stosb
     ret
 
     ; --------------------------------------------------------------------------

--- a/boot/setup32.asm
+++ b/boot/setup32.asm
@@ -387,8 +387,8 @@ copy_cmdline:
     lodsb                           ; load next character
 
     dec ecx                         ; decrement max length counter
-    jnz .continue_copy               ; if we reached maximum length...
-    xor al, 0                       ; ... NUL terminate string and stop
+    jnz .continue_copy              ; if we reached maximum length...
+    xor al, al                      ; ... NUL terminate string and stop
 
 .continue_copy
     stosb                           ; store character in destination

--- a/boot/setup32.asm
+++ b/boot/setup32.asm
@@ -168,6 +168,7 @@
 #include <hal/asm/memory.h>
 #include <hal/asm/vm.h>
 #include <hal/asm/x86.h>
+#include <asm/cmdline.h>
 
 ; Stack frame variables and size
 #define VAR_ZERO_PAGE       0
@@ -372,7 +373,7 @@ copy_e820_memory_map:
     ;
     ; Returns:
     ;       edi end of kernel command line
-    ;       eax, esi are caller saved
+    ;       eax, ecx, esi are caller saved
 copy_cmdline:
     mov dword [ebp + BOOT_INFO_CMDLINE], empty_string
 
@@ -380,11 +381,16 @@ copy_cmdline:
     or esi, esi                     ; if command line pointer is NULL...
     jz .skip                        ; ... skip copy and keep empty string
 
-    ; Following the e820 memory map copy above, edi is already where we
-    ; want it to be.
     mov dword [ebp + BOOT_INFO_CMDLINE], edi
+    mov ecx, CMDLINE_MAX_PARSE_LENGTH
 .copy:
     lodsb                           ; load next character
+
+    dec ecx                         ; decrement max length counter
+    jnz .continue_copy               ; if we reached maximum length...
+    xor al, 0                       ; ... NUL terminate string and stop
+
+.continue_copy
     stosb                           ; store character in destination
     or al, al                       ; if character is not terminating NUL...
     jnz .copy                       ; ... continue with next character

--- a/include/asm/cmdline.h
+++ b/include/asm/cmdline.h
@@ -29,38 +29,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_CMDLINE_H
-#define JINUE_KERNEL_CMDLINE_H
+#ifndef JINUE_KERNEL_ASM_CMDLINE_H
+#define JINUE_KERNEL_ASM_CMDLINE_H
 
-#include <asm/cmdline.h>
-#include <types.h>
+/** Maximum valid command line length
+ *
+ * Here, the limiting factor is the size of the user loader's stack since these
+ * options will end up on its command line or its environment.
+ *
+ * TODO we need to upgrade to boot protocol 2.06+ before we can increase this. */
+#define CMDLINE_MAX_VALID_LENGTH    255
 
-typedef enum {
-    CMDLINE_OPT_PAE_AUTO,
-    CMDLINE_OPT_PAE_DISABLE,
-    CMDLINE_OPT_PAE_REQUIRE
-} cmdline_opt_pae_t;
-
-typedef struct {
-    cmdline_opt_pae_t    pae;
-    bool                 serial_enable;
-    int                  serial_baud_rate;
-    int                  serial_ioport;
-    bool                 vga_enable;
-} cmdline_opts_t;
-
-void cmdline_parse_options(const char *cmdline);
-
-const cmdline_opts_t *cmdline_get_options(void);
-
-void cmdline_report_parsing_errors(void);
-
-char *cmdline_write_arguments(char *buffer, const char *cmdline);
-
-char *cmdline_write_environ(char *buffer, const char *cmdline);
-
-size_t cmdline_count_arguments(const char *cmdline);
-
-size_t cmdline_count_environ(const char *cmdline);
+/** Maximum command line length that cmdline_parse_options() will attempt to parse
+ *
+ * cmdline_parse_options() can really parse any length. The intent here is to
+ * attempt to detect a missing NUL terminator. */
+#define CMDLINE_MAX_PARSE_LENGTH    (1000 * 1000)
 
 #endif

--- a/include/asm/cmdline.h
+++ b/include/asm/cmdline.h
@@ -37,10 +37,8 @@
 /** Maximum valid command line length
  *
  * Here, the limiting factor is space on the user stack for command line
- * arguments, environment variables and associated indexing string arrays.
- *
- * TODO we need to upgrade to boot protocol 2.06+ before we can increase this. */
-#define CMDLINE_MAX_VALID_LENGTH    255
+ * arguments, environment variables and associated indexing string arrays. */
+#define CMDLINE_MAX_VALID_LENGTH    4096
 
 /** Maximum command line length that the kernel will copy and attempt to parse
  *

--- a/include/asm/cmdline.h
+++ b/include/asm/cmdline.h
@@ -32,18 +32,24 @@
 #ifndef JINUE_KERNEL_ASM_CMDLINE_H
 #define JINUE_KERNEL_ASM_CMDLINE_H
 
+#include <jinue-common/asm/types.h>
+
 /** Maximum valid command line length
  *
- * Here, the limiting factor is the size of the user loader's stack since these
- * options will end up on its command line or its environment.
+ * Here, the limiting factor is space on the user stack for command line
+ * arguments, environment variables and associated indexing string arrays.
  *
  * TODO we need to upgrade to boot protocol 2.06+ before we can increase this. */
 #define CMDLINE_MAX_VALID_LENGTH    255
 
-/** Maximum command line length that cmdline_parse_options() will attempt to parse
+/** Maximum command line length that the kernel will copy and attempt to parse
  *
- * cmdline_parse_options() can really parse any length. The intent here is to
- * attempt to detect a missing NUL terminator. */
-#define CMDLINE_MAX_PARSE_LENGTH    (1000 * 1000)
+ * The real maximum length for the command line is CMDLINE_MAX_VALID_LENGTH, and
+ * the limiting factor is space on the user stack for command line arguments,
+ * environment variables and associated indexing string arrays. The kernel
+ * will actually attempt to parse more than this to maximize chances it gets
+ * the options that affect logging right when it logs the "kernel command line
+ * is too long" error message, up to the length specified here. */
+#define CMDLINE_MAX_PARSE_LENGTH    (64 * KB)
 
 #endif

--- a/kernel/cmdline.c
+++ b/kernel/cmdline.c
@@ -37,20 +37,6 @@
 #include <printk.h>
 #include <string.h>
 
-/** Maximum valid command line length
- *
- * Here, the limiting factor is the size of the user loader's stack since these
- * options will end up on its command line or its environment.
- *
- * TODO we need to upgrade to boot protocol 2.06+ before we can increase this. */
-#define CMDLINE_MAX_VALID_LENGTH    255
-
-/** Maximum command line length that cmdline_parse_options() will attempt to parse
- *
- * cmdline_parse_options() can really parse any length. The intent here is to
- * attempt to detect a missing NUL terminator. */
-#define CMDLINE_MAX_PARSE_LENGTH    (1000 * 1000)
-
 #define CMDLINE_ERROR_TOO_LONG                  (1<<0)
 
 #define CMDLINE_ERROR_IS_NULL                   (1<<1)


### PR DESCRIPTION
* Support kernel command line length > 255 characters.
* Ensure the setup code handles overly long command lines in a reasonable way when copying the command line.