### PR TITLE
Fix argument mapping for CREATE_THREAD

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -129,8 +129,8 @@ static void sys_puts(jinue_syscall_args_t *args) {
 }
 
 static void sys_create_thread(jinue_syscall_args_t *args) {
-    void *entry         = (void *)args->arg2;
-    void *user_stack    = (void *)args->arg3;
+    void *entry         = (void *)args->arg1;
+    void *user_stack    = (void *)args->arg2;
 
     if(!is_userspace_pointer(entry)) {
         syscall_args_set_error(args, JINUE_EINVAL);

--- a/lib/jinue/syscall.c
+++ b/lib/jinue/syscall.c
@@ -106,9 +106,9 @@ int jinue_create_thread(void (*entry)(), void *stack, int *perrno) {
     jinue_syscall_args_t args;
 
     args.arg0 = SYSCALL_FUNC_CREATE_THREAD;
-    args.arg1 = 0;
-    args.arg2 = (uintptr_t)entry;
-    args.arg3 = (uintptr_t)stack;
+    args.arg1 = (uintptr_t)entry;
+    args.arg2 = (uintptr_t)stack;
+    args.arg3 = 0;
 
     return jinue_syscall_with_usual_convention(&args, perrno);
 }


### PR DESCRIPTION
Fix argument mappings for the CREATE_THREAD system call to match the [documentation](https://github.com/phaubertin/jinue/blob/main/doc/syscalls/create-thread.md), i.e. map to `arg1` and `arg2` rather than `arg2` and `arg3`.