### PR TITLE
Build portability improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "explorer.excludeGitIgnore": true
+    "explorer.excludeGitIgnore": true,
+    "makefile.configureOnOpen": false
 }

--- a/devel/qemu/Makefile
+++ b/devel/qemu/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Philippe Aubertin.
+# Copyright (C) 2022-2024 Philippe Aubertin.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -96,7 +96,29 @@ $(kernel_img_copy): $(kernel_img) $(temp_iso_fs) kernel-image
 	cp $< $@
 
 $(grub_image): $(initrd) $(kernel_img_copy)
-	grub2-mkimage --prefix '/boot/grub' --output $(grub_image) --format i386-pc-eltorito --compression auto --config $(grub_config) biosdisk iso9660
+	`grub2-mkimage --version > /dev/null 2>&1 && echo grub2-mkimage || echo grub-mkimage` \
+		--prefix '/boot/grub' \
+		--output $(grub_image) \
+		--format i386-pc-eltorito \
+		--compression auto \
+		--config $(grub_config) \
+		biosdisk iso9660
 
 $(jinue_iso): $(grub_image)
-	xorriso -as mkisofs -graft-points -b $(grub_image_rel) -no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info --grub2-mbr $(grub_modules)/boot_hybrid.img --protective-msdos-label -o $(jinue_iso) -r $(temp_iso_fs) --sort-weight 0 / --sort-weight 1 /boot
+	xorriso \
+		-as mkisofs \
+		-graft-points \
+		-b $(grub_image_rel) \
+		-no-emul-boot \
+		-boot-load-size 4 \
+		-boot-info-table \
+		--grub2-boot-info \
+		--grub2-mbr \
+		$(grub_modules)/boot_hybrid.img \
+		--protective-msdos-label \
+		-o $(jinue_iso) \
+		-r $(temp_iso_fs) \
+		--sort-weight 0 \
+		/ \
+		--sort-weight 1 \
+		/boot

--- a/devel/virtualbox/Makefile
+++ b/devel/virtualbox/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Philippe Aubertin.
+# Copyright (C) 2022-2024 Philippe Aubertin.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -78,7 +78,29 @@ $(kernel_img_copy): $(kernel_img) $(temp_iso_fs) kernel-image
 	cp $< $@
 
 $(grub_image): $(initrd) $(kernel_img_copy)
-	grub2-mkimage --prefix '/boot/grub' --output $(grub_image) --format i386-pc-eltorito --compression auto --config $(grub_config) biosdisk iso9660
+	`grub2-mkimage --version > /dev/null 2>&1 && echo grub2-mkimage || echo grub-mkimage` \
+		--prefix '/boot/grub' \
+		--output $(grub_image) \
+		--format i386-pc-eltorito \
+		--compression auto \
+		--config $(grub_config) \
+		biosdisk iso9660
 
 $(jinue_iso): $(grub_image)
-	xorriso -as mkisofs -graft-points -b $(grub_image_rel) -no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info --grub2-mbr $(grub_modules)/boot_hybrid.img --protective-msdos-label -o $(jinue_iso) -r $(temp_iso_fs) --sort-weight 0 / --sort-weight 1 /boot
+	xorriso \
+		-as mkisofs \
+		-graft-points \
+		-b $(grub_image_rel) \
+		-no-emul-boot \
+		-boot-load-size 4 \
+		-boot-info-table \
+		--grub2-boot-info \
+		--grub2-mbr \
+		$(grub_modules)/boot_hybrid.img \
+		--protective-msdos-label \
+		-o $(jinue_iso) \
+		-r $(temp_iso_fs) \
+		--sort-weight 0 \
+		/ \
+		--sort-weight 1 \
+		/boot

--- a/header.mk
+++ b/header.mk
@@ -109,7 +109,7 @@ CPPFLAGS             = $(CPPFLAGS.includes) $(CPPFLAGS.debug) $(CPPFLAGS.others)
 CFLAGS.warnings      = -std=c99 -pedantic -Wall -Werror=implicit -Werror=uninitialized -Werror=return-type
 CFLAGS.arch          = -m32 -march=i686
 CFLAGS.optimization  = -O3
-CFLAGS.others        = -ffreestanding -fno-common -fno-omit-frame-pointer -fno-delete-null-pointer-checks
+CFLAGS.others        = -ffreestanding -fno-pie -fno-common -fno-omit-frame-pointer -fno-delete-null-pointer-checks
 CFLAGS               = $(CFLAGS.arch) $(CFLAGS.optimization) $(CFLAGS.debug) $(CFLAGS.warnings) $(CFLAGS.others) $(CFLAGS.extra)
 
 # Linker flags

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,7 +34,7 @@ kernel_ldscript  = i686/ld/kernel.ld
 image_ldscript   = i686/ld/image.ld
 build_info_h     = build-info.gen.h
 
-LDFLAGS         += -m32 -march=i686
+LDFLAGS         += -m32 -march=i686 -Wl,-z,noseparate-code
 KERNEL_LDFLAGS   = -T $(kernel_ldscript) -static-libgcc
 KERNEL_LDLIBS    = -lgcc
 IMAGE_LDFLAGS    = -T $(image_ldscript)


### PR DESCRIPTION
A few changes to improve build portability:

* Pass `-z noseparate-code` when linking since the kernel currently does not support the separate read-only segments when it loads the loader ELF binary.
* Pass `-fno-pie` to gcc when compiling since `-fpie` is more often the default with recent gcc versions and/or Linux distributions.
* Fallback to `grub-mkimage` if `grub2-mkimage` is not found when building the ISO image for QEMU or VirtualBox.

Known to build and run in QEMU:

* On Debian 12.7
* On CentOS 7