### PR TITLE
Fixes in initialize_initial_page_tables()

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,7 +34,7 @@ kernel_ldscript  = i686/ld/kernel.ld
 image_ldscript   = i686/ld/image.ld
 build_info_h     = build-info.gen.h
 
-LDFLAGS         += -m32 -march=i686 -Wl,-z,noseparate-code
+LDFLAGS         += -m32 -march=i686
 KERNEL_LDFLAGS   = -T $(kernel_ldscript) -static-libgcc
 KERNEL_LDLIBS    = -lgcc
 IMAGE_LDFLAGS    = -T $(image_ldscript)

--- a/kernel/i686/vm.c
+++ b/kernel/i686/vm.c
@@ -363,19 +363,21 @@ static void initialize_initial_page_tables(
         panic("could not find kernel executable segment");
     }
 
-    size_t code_offset = ((uintptr_t)phdr->p_vaddr - KLIMIT) / PAGE_SIZE;
+    uintptr_t code_vaddr    = ALIGN_START((uintptr_t)phdr->p_vaddr, PAGE_SIZE);
+    size_t code_size        = phdr->p_memsz + OFFSET_OF_PTR(phdr->p_vaddr, PAGE_SIZE);
+    size_t code_offset      = (code_vaddr - KLIMIT) / PAGE_SIZE;
 
     vm_initialize_page_table_linear(
-            vm_pae_get_pte_with_offset(page_tables, code_offset),
-            phdr->p_vaddr + MEMORY_ADDR_16MB - KLIMIT,
+            get_pte_with_offset(page_tables, code_offset),
+            code_vaddr + MEMORY_ADDR_16MB - KLIMIT,
             X86_PTE_GLOBAL,
-            phdr->p_memsz / PAGE_SIZE);
+            code_size / PAGE_SIZE);
 
     /* map kernel data segment */
     size_t data_offset = ((uintptr_t)boot_info->data_start - KLIMIT) / PAGE_SIZE;
 
     vm_initialize_page_table_linear(
-            vm_pae_get_pte_with_offset(page_tables, data_offset),
+            get_pte_with_offset(page_tables, data_offset),
             boot_info->data_physaddr + MEMORY_ADDR_16MB - MEMORY_ADDR_1MB,
             X86_PTE_GLOBAL | X86_PTE_READ_WRITE | X86_PTE_NX,
             boot_info->data_size / PAGE_SIZE);


### PR DESCRIPTION
Two fixes in `initialize_initial_page_tables()`:

* Replace mistaken use of `vm_pae_get_pte_with_offset()` instead of `get_pte_with_offset()`. This fixes a failed assertion in non-PAE mode.
* Properly handle unaligned code segment in the kernel ELF binary so it's no longer necessary to link with ` -Wl,-z,noseparate-code`.