### PR TITLE
get_current_process()

### DIFF
--- a/include/kernel/process.h
+++ b/include/kernel/process.h
@@ -46,4 +46,6 @@ int process_create_syscall(int fd);
 
 void process_switch_to(process_t *process);
 
+process_t *get_current_process(void);
+
 #endif

--- a/kernel/descriptor.c
+++ b/kernel/descriptor.c
@@ -30,7 +30,6 @@
  */
 
 #include <jinue/shared/asm/errno.h>
-#include <kernel/i686/thread.h>
 #include <kernel/descriptor.h>
 #include <kernel/ipc.h>
 #include <kernel/object.h>
@@ -135,12 +134,7 @@ int dereference_unused_descriptor(
 static int get_process(process_t **process, int process_fd) {
     object_header_t *object;
 
-    int status = dereference_object_descriptor(
-            &object,
-            NULL,
-            get_current_thread()->process,
-            process_fd
-    );
+    int status = dereference_object_descriptor(&object, NULL, get_current_process(), process_fd);
 
     if(status < 0) {
         return status;
@@ -165,7 +159,7 @@ int dup(int process_fd, int src, int dest) {
 
     object_header_t *object;
     object_ref_t *src_ref;
-    status = dereference_object_descriptor(&object, &src_ref, get_current_thread()->process, src);
+    status = dereference_object_descriptor(&object, &src_ref, get_current_process(), src);
 
     if(status < 0) {
         return status;
@@ -212,12 +206,7 @@ int mint(int owner, const jinue_mint_args_t *mint_args) {
     object_header_t *object;
     object_ref_t    *src_ref;
     
-    int status = dereference_object_descriptor(
-        &object,
-        &src_ref,
-        get_current_thread()->process,
-        owner
-    );
+    int status = dereference_object_descriptor(&object, &src_ref, get_current_process(), owner);
 
     if(status < 0) {
         return status;
@@ -264,7 +253,7 @@ int mint(int owner, const jinue_mint_args_t *mint_args) {
 int close(int fd) {
     object_header_t *object;
     object_ref_t *ref;
-    int status = dereference_object_descriptor(&object, &ref, get_current_thread()->process, fd);
+    int status = dereference_object_descriptor(&object, &ref, get_current_process(), fd);
 
     if(status < 0) {
         return status;
@@ -280,7 +269,7 @@ int close(int fd) {
 int destroy(int fd) {
     object_header_t *object;
     object_ref_t *ref;
-    int status = dereference_object_descriptor(&object, &ref, get_current_thread()->process, fd);
+    int status = dereference_object_descriptor(&object, &ref, get_current_process(), fd);
 
     if(status < 0) {
         return status;

--- a/kernel/i686/vm.c
+++ b/kernel/i686/vm.c
@@ -34,7 +34,6 @@
 #include <kernel/i686/boot.h>
 #include <kernel/i686/cpu_data.h>
 #include <kernel/i686/memory.h>
-#include <kernel/i686/thread.h>
 #include <kernel/i686/vga.h>
 #include <kernel/i686/vm.h>
 #include <kernel/i686/vm_private.h>
@@ -927,12 +926,7 @@ kern_paddr_t vm_lookup_kernel_paddr(void *addr) {
 
 static int get_addr_space_by_descriptor(addr_space_t **addr_space, int fd) {
     object_header_t *object;
-    int status = dereference_object_descriptor(
-            &object,
-            NULL,
-            get_current_thread()->process,
-            fd
-    );
+    int status = dereference_object_descriptor(&object, NULL, get_current_process(), fd);
 
     if(status < 0) {
         return status;

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -128,3 +128,7 @@ void process_switch_to(process_t *process) {
             &process->addr_space,
             get_cpu_local_data());
 }
+
+process_t *get_current_process(void) {
+    return get_current_thread()->process;
+}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -63,12 +63,7 @@ int thread_create_syscall(
         void            *user_stack) {
     object_header_t *object;
 
-    int status = dereference_object_descriptor(
-            &object,
-            NULL,
-            get_current_thread()->process,
-            process_fd
-    );
+    int status = dereference_object_descriptor(&object, NULL, get_current_process(), process_fd);
 
     if(status < 0) {
         return status;


### PR DESCRIPTION
Create `get_current_thread()` to reduce repetition and dependencies on the machine-specific threading code.