### PR TITLE
Fix clang warnings

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -35,7 +35,7 @@ image_ldscript   = i686/ld/image.ld
 build_info_h     = build-info.gen.h
 
 LDFLAGS         += -m32 -march=i686
-KERNEL_LDFLAGS   = -T $(kernel_ldscript) -static-libgcc
+KERNEL_LDFLAGS   = -T $(kernel_ldscript)
 KERNEL_LDLIBS    = -lgcc
 IMAGE_LDFLAGS    = -T $(image_ldscript)
 

--- a/userspace/loader/Makefile
+++ b/userspace/loader/Makefile
@@ -52,7 +52,7 @@ CPPFLAGS        += -I$(zlib) -DZLIB_CONST
 # in this regard on different machines with different versions of the
 # linker. By explicitly forcing _start as an undefined symbol, we
 # ensure the linker links the startup code.
-LDFLAGS         += -Wl,-u,_start -static-libgcc -m32 -march=i686
+LDFLAGS         += -Wl,-u,_start -m32 -march=i686
 LDLIBS           = -lgcc
 
 unclean.extra    = $(loader)

--- a/userspace/loader/elf/elf.c
+++ b/userspace/loader/elf/elf.c
@@ -398,9 +398,9 @@ extern char **environ;
  *
  * */
 size_t count_environ(void) {
-    int n;
+    int n = 0;
 
-    for(n = 0; environ[n] != NULL; ++n) {
+    while(environ[n] != NULL) {
         ++n;
     }
 

--- a/userspace/testapp/Makefile
+++ b/userspace/testapp/Makefile
@@ -44,7 +44,7 @@ unclean_recursive	 = $(temp_ramdisk_fs)
 # in this regard on different machines with different versions of the
 # linker. By explicitly forcing _start as an undefined symbol, we
 # ensure the linker links the startup code.
-LDFLAGS         += -Wl,-u,_start -static-libgcc -m32 -march=i686
+LDFLAGS         += -Wl,-u,_start -m32 -march=i686
 LDLIBS           = -lgcc
 
 unclean.extra    = $(testapp)


### PR DESCRIPTION
Compiled with `CC=clang make`, then fixed warnings flagged by `clang`.

Changes:
* Small bug in `userspace/loader/elf/elf.c` flagged by a `clang` warning.
* Remove `-static-libgcc` option when linking.