### PR TITLE
Fix default branch name in workflow

### DIFF
--- a/.github/workflows/build-i686.yml
+++ b/.github/workflows/build-i686.yml
@@ -2,7 +2,7 @@ name: Build for i686
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
   pull_request:
     branches: [ '*' ]
 


### PR DESCRIPTION
`$default-branch` only works in workflow _templates_, not in workflows. Replace with actual branch name.