### PR TITLE
Add clang to build workflow

### DIFF
--- a/.github/workflows/build-i686.yml
+++ b/.github/workflows/build-i686.yml
@@ -9,7 +9,14 @@ on:
 jobs:
   build:
 
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+
     runs-on: ubuntu-latest
+
+    env:
+      MAKE: make CC="${{ matrix.cc }} -Werror"
 
     steps:
 
@@ -24,13 +31,13 @@ jobs:
       run: ./configure
 
     - name: make
-      run: make
+      run: ${{ env.MAKE }}
 
     - name: make testapp
-      run: make testapp
+      run: ${{ env.MAKE }} testapp
     
     - name: make qemu
-      run: make qemu
+      run: ${{ env.MAKE }} qemu
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -40,4 +47,4 @@ jobs:
           userspace/testapp/testapp
     
     - name: make qemu-check
-      run: make qemu-check
+      run: ${{ env.MAKE }} qemu-check

--- a/.github/workflows/build-i686.yml
+++ b/.github/workflows/build-i686.yml
@@ -42,7 +42,8 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-       path: |
+        name: artifact-${{ matrix.cc }}
+        path: |
           kernel/interface/i686/jinue
           userspace/testapp/testapp
     


### PR DESCRIPTION
Build with both gcc and clang. Add `-Werror` in workflow for both compilers.
