### PR TITLE
Add testapp initrd to build artifacts

### DIFF
--- a/.github/workflows/build-i686.yml
+++ b/.github/workflows/build-i686.yml
@@ -45,7 +45,7 @@ jobs:
         name: artifact-${{ matrix.cc }}
         path: |
           kernel/interface/i686/jinue
-          userspace/testapp/testapp
+          userspace/testapp/jinue-testapp-initrd.tar.gz
     
     - name: make qemu-check
       run: ${{ env.MAKE }} qemu-check

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -43,7 +43,7 @@ c.lib            = $(libc)/libc-kernel.a
 loader.bin       = $(loader)/loader
 
 kernel_elf       = interface/i686/kernel
-stripped         = interface/i686/kernel-stripped
+stripped         = $(kernel_elf)-stripped
 image            = interface/i686/$(notdir $(kernel_img))
 kmain			 = application/kmain.o
 setup16          = interface/i686/setup16.o

--- a/userspace/testapp/Makefile
+++ b/userspace/testapp/Makefile
@@ -32,6 +32,7 @@ include $(jinue_root)/header.mk
 
 sources.c       	 = tests/ipc.c debug.c testapp.c util.c
 testapp         	 = testapp
+stripped             = $(testapp)-stripped
 temp_ramdisk_fs		 = ramdisk-tmp
 ramdisk 			 = $(notdir $(testapp_initrd))
 
@@ -47,7 +48,7 @@ unclean_recursive	 = $(temp_ramdisk_fs)
 LDFLAGS         += -Wl,-u,_start -m32 -march=i686
 LDLIBS           = -lgcc
 
-unclean.extra    = $(testapp)
+unclean.extra    = $(testapp) $(stripped)
 
 include $(common)
 
@@ -59,9 +60,11 @@ $(libc)/libc.a: FORCE
 
 $(testapp): $(objects) $(libjinue)/libjinue-util.a $(libc)/libc.a $(libjinue)/libjinue-syscalls.a
 
-$(temp_ramdisk_fs): $(testapp)
+$(stripped): $(testapp)
+
+$(temp_ramdisk_fs): $(stripped)
 	mkdir -p $(temp_ramdisk_fs)/sbin
-	cp $(testapp) $(temp_ramdisk_fs)/sbin/init
+	cp $(stripped) $(temp_ramdisk_fs)/sbin/init
 	touch $(temp_ramdisk_fs)
 
 $(ramdisk): $(temp_ramdisk_fs)


### PR DESCRIPTION
In GitHub workflow, add testapp initrd to build artifacts instead of testapp ELF file. Also, strip testapp ELF file.