### PR TITLE
Cleanup leftover references to hal/ 

### DIFF
--- a/doc/layout.md
+++ b/doc/layout.md
@@ -70,10 +70,10 @@ prints debugging information.)
 
 ## 32-bit Setup Code
 
-The [32-bit setup code](../boot/setup32.asm) is the first part of the kernel
-to run (after the 16-bit setup code if the 16-bit boot protocol is used). It
-performs a few tasks necessary to provide the kernel proper the execution
-environment it needs. These tasks include:
+The [32-bit setup code](../kernel/interface/i686/setup32.asm) is the first part
+of the kernel to run (after the 16-bit setup code if the 16-bit boot protocol
+is used). It performs a few tasks necessary to provide the kernel proper the
+execution environment it needs. These tasks include:
 
 * Allocating a boot-time stack and heap;
 * Copying the BIOS memory map and the kernel command line;
@@ -137,16 +137,16 @@ address = physical address). This mapping contains the kernel image, other data
 set up by the bootloader as well as the VGA text video memory. The kernel image
 is mapped read only while the rest of the memory is mapped read/write.
 2. Starting at address 0x1000000 (i.e. 16MB), a few megabytes of memory
-(size [BOOT_SIZE_AT_16MB](../include/hal/asm/boot.h)) are also identity mapped.
-Early in the initialization process, the kernel move its own image there. This
-region is mapped read/write.
+(size [BOOT_SIZE_AT_16MB](../include/kernel/interface/i686//asm/boot.h)) are
+also identity mapped. Early in the initialization process, the kernel move its
+own image there. This region is mapped read/write.
 3. The kernel image as well as some of the initial memory allocations, up to but
 excluding the initial page tables, are mapped at address 0xc000000 (3GB,
-aka. [KLIMIT](../include/jinue-common/asm/vm.h)). This is the address where the
-kernel expects to be loaded and ran. This is a linear mapping with one
-exception: the kernel's data segment is a copy of the content in the ELF binary,
-with appropriate zero-padding for uninitialized data (i.e. the .bss section) and
-the copy is mapped read/write at the address where the kernel expects to find
+aka. [KLIMIT](../include/kernel/infrastructure/i686/asm/shared.h)). This is the
+address where the kernel expects to be loaded and ran. This is a linear mapping
+with one exception: the kernel's data segment is a copy of the content in the ELF
+binary, with appropriate zero-padding for uninitialized data (i.e. the .bss section)
+and the copy is mapped read/write at the address where the kernel expects to find
 it. The rest of the kernel image is mapped read only and the rest of the region
 (initial allocations) is read/write.
 

--- a/include/kernel/infrastructure/i686/vm.h
+++ b/include/kernel/infrastructure/i686/vm.h
@@ -32,8 +32,9 @@
 #ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_VM_H
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_VM_H
 
-/** This header file contains the public interface of the low-level page table
- * management code located in hal/vm.c and hal/vm_pae.c. */
+/** This header file contains the interface exposed to the rest of the kernel's
+ * i686-specific code of the low-level page table management functions defined
+ * in vm.c and vm_pae.c located in kernel/infrastructure/i686/. */
 
 #include <jinue/shared/vm.h>
 #include <kernel/infrastructure/i686/asm/vm.h>

--- a/include/kernel/infrastructure/i686/vm_pae.h
+++ b/include/kernel/infrastructure/i686/vm_pae.h
@@ -33,8 +33,8 @@
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_VM_PAE_H
 
 /** This header file contains declarations for the PAE functions defined in
- * hal/vm_pae.c. It is intended to be included by hal/vm.c and hal/vm_pae.c.
- * There should be no reason to include it anywhere else. */
+ * kernel/infrastructure/i686/vm_pae.c. It is intended to be included by vm.c
+ * and vm_pae.c. There should be no reason to include it anywhere else. */
 
 #include <kernel/infrastructure/i686/types.h>
 #include <kernel/interface/i686/types.h>

--- a/include/kernel/infrastructure/i686/vm_private.h
+++ b/include/kernel/infrastructure/i686/vm_private.h
@@ -41,8 +41,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/** This header file contains private definitions shared by hal/vm.c, hal/vm_pae.c
- *  and hal/vm_x86.c. There should be no reason to include it anywhere else. */
+/** This header file contains private definitions shared by vm.c, vm_pae.c
+ * and vm_x86.c in kernel/infrastructure/i686/. There should be no reason to
+ * include it anywhere else. */
 
 /** bit mask for page table or page directory offset */
 #define PAGE_TABLE_MASK (PAGE_TABLE_ENTRIES - 1)

--- a/include/kernel/infrastructure/i686/vm_x86.h
+++ b/include/kernel/infrastructure/i686/vm_x86.h
@@ -33,8 +33,8 @@
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_VM_X86_H
 
 /** This header file contains declarations for the non-PAE functions defined in
- * hal/vm_x86.c. It is intended to be included by hal/vm.c and hal/vm_x86.c.
- * There should be no reason to include it anywhere else. */
+ * kernel/infrastructure/i686/vm_x86.c. It is intended to be included by vm.c
+ * and vm_x86.c. There should be no reason to include it anywhere else. */
 
 #include <kernel/infrastructure/i686/types.h>
 


### PR DESCRIPTION
* Cleanup leftover references to `hal/`.
* Fix some broken links in ducumentation.