### PR TITLE
Proper cleanup when endpoint is destroyed

### DIFF
--- a/include/kernel/domain/entities/object.h
+++ b/include/kernel/domain/entities/object.h
@@ -50,7 +50,7 @@ static inline bool object_is_destroyed(object_header_t *object) {
 }
 
 static inline void init_object_header(object_header_t *object, const object_type_t *type) {
-    object->type = type;
+    object->type        = type;
     object->ref_count   = 0;
     object->flags       = OBJECT_FLAG_NONE;
 }
@@ -59,15 +59,14 @@ static inline void add_ref_to_object(object_header_t *object) {
     ++object->ref_count;
 }
 
-static inline void sub_ref_to_object(object_header_t *object) {
-    /** TODO free at zero */
-    --object->ref_count;
-}
-
 void init_object_cache(slab_cache_t *cache, const object_type_t *type);
 
 void open_object(object_header_t *object, const descriptor_t *desc);
 
 void close_object(object_header_t *object, const descriptor_t *desc);
+
+void destroy_object(object_header_t *object);
+
+void sub_ref_to_object(object_header_t *object);
 
 #endif

--- a/include/kernel/domain/entities/process.h
+++ b/include/kernel/domain/entities/process.h
@@ -40,8 +40,6 @@ void initialize_process_cache(void);
 
 process_t *construct_process(void);
 
-void free_process(process_t *process);
-
 void switch_to_process(process_t *process);
 
 process_t *get_current_process(void);

--- a/include/kernel/domain/services/ipc.h
+++ b/include/kernel/domain/services/ipc.h
@@ -43,6 +43,8 @@ int send_message(
 
 int receive_message(ipc_endpoint_t *endpoint, thread_t *receiver,jinue_message_t *message);
 
-int send_reply(thread_t *replier, const jinue_message_t *message);
+int reply_to_message(thread_t *replier, const jinue_message_t *message);
+
+void abort_message(thread_t *thread, int errno);
 
 #endif

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -60,12 +60,16 @@ typedef struct object_header_t object_header_t;
 
 typedef void (*descriptor_func_t)(object_header_t *, const descriptor_t *);
 
+typedef void (*object_func_t)(object_header_t *);
+
 typedef struct {
     int                  all_permissions;
     char                *name;
     size_t               size;
     descriptor_func_t    open;
     descriptor_func_t    close;
+    object_func_t        destroy;
+    object_func_t        free;
     slab_ctor_t          cache_ctor;
     slab_ctor_t          cache_dtor;
 } object_type_t;
@@ -99,7 +103,7 @@ struct thread_t {
     size_t                   local_storage_size;
     struct thread_t         *sender;
     size_t                   recv_buffer_size;
-    int                      reply_errno;
+    int                      message_errno;
     uintptr_t                message_function;
     uintptr_t                message_cookie;
     size_t                   message_size;

--- a/kernel/application/syscalls/destroy.c
+++ b/kernel/application/syscalls/destroy.c
@@ -32,6 +32,7 @@
 #include <jinue/shared/asm/errno.h>
 #include <kernel/application/syscalls.h>
 #include <kernel/domain/entities/descriptor.h>
+#include <kernel/domain/entities/endpoint.h>
 #include <kernel/domain/entities/object.h>
 #include <kernel/domain/entities/process.h>
 
@@ -43,15 +44,20 @@ int destroy(int fd) {
         return status;
     }
 
+    object_header_t *object = desc->object;
+
+    /* TODO support other object types */
+    if(object->type != object_type_ipc_endpoint) {
+        return -JINUE_EBADF;
+    }
+
     if(!descriptor_is_owner(desc)) {
         return -JINUE_EPERM;
     }
 
-    object_header_t *object = desc->object;
+    destroy_object(object);
 
     close_object(object, desc);
-
-    mark_object_destroyed(object);
 
     desc->flags = DESCRIPTOR_FLAG_NONE;
 

--- a/kernel/application/syscalls/reply.c
+++ b/kernel/application/syscalls/reply.c
@@ -37,5 +37,5 @@
 
 int reply(const jinue_message_t *message) {
     thread_t *replier = get_current_thread();
-    return send_reply(replier, message);
+    return reply_to_message(replier, message);
 }

--- a/kernel/domain/entities/object.c
+++ b/kernel/domain/entities/object.c
@@ -59,3 +59,29 @@ void close_object(object_header_t *object, const descriptor_t *desc) {
 
     sub_ref_to_object(object);
 }
+
+void destroy_object(object_header_t *object) {
+    if(object_is_destroyed(object)) {
+        return;
+    }
+
+    mark_object_destroyed(object);
+
+    if(object->type->destroy != NULL) {
+        object->type->destroy(object);
+    }
+}
+
+void sub_ref_to_object(object_header_t *object) {
+    --object->ref_count;
+
+    if(object->ref_count > 0) {
+        return;
+    }
+
+    destroy_object(object);
+
+    if(object->type->free != NULL) {
+        object->type->free(object);
+    }
+}

--- a/kernel/domain/entities/process.c
+++ b/kernel/domain/entities/process.c
@@ -42,6 +42,10 @@
 
 static void cache_process_ctor(void *buffer, size_t ignore);
 
+static void destroy_process(object_header_t *object);
+
+static void free_process(object_header_t *object);
+
 /** runtime type definition for a process */
 static const object_type_t object_type = {
     .all_permissions    =
@@ -53,6 +57,8 @@ static const object_type_t object_type = {
     .size               = sizeof(process_t),
     .open               = NULL,
     .close              = NULL,
+    .destroy            = destroy_process,
+    .free               = free_process,
     .cache_ctor         = cache_process_ctor,
     .cache_dtor         = NULL
 };
@@ -91,11 +97,15 @@ process_t *construct_process(void) {
     return process;
 }
 
-void free_process(process_t *process) {
+static void destroy_process(object_header_t *object) {
+    process_t *process = (process_t *)object;
     /* TODO destroy remaining threads */
     /* TODO finalize descriptors */
     machine_finalize_process(process);
-    slab_cache_free(process);
+}
+
+static void free_process(object_header_t *object) {
+    slab_cache_free(object);
 }
 
 void switch_to_process(process_t *process) {

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -46,6 +46,8 @@ static const object_type_t object_type = {
     .size               = sizeof(thread_t),
     .open               = NULL,
     .close              = NULL,
+    .destroy            = NULL,
+    .free               = NULL,
     .cache_ctor         = NULL,
     .cache_dtor         = NULL
 };


### PR DESCRIPTION
* Perform proper cleanup when and IPC endpoint is destroyed.
* Actually free an IPC endpoint or process with no reference.
