### PR TITLE
Decouple thread startup from thread creation

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (C) 2019-2022 Philippe Aubertin.
+Copyright (C) 2019-2024 Philippe Aubertin.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/devel/qemu/check-log.sh
+++ b/devel/qemu/check-log.sh
@@ -110,6 +110,9 @@ echo "$RESULT" | grep -F 'I/O error' || fail
 echo "* Check client thread exited cleanly"
 grep -F "Client thread is exiting." $1 || fail
 
+echo "* Check main thread joined the client thread and retreived its exit value"
+grep -F "Client thread exit value is 42." $1 || fail
+
 echo "* Check the main thread initiated the reboot"
 grep -F "Main thread is running." $1 || fail
 grep -F "Rebooting." $1 || fail

--- a/devel/qemu/check-log.sh
+++ b/devel/qemu/check-log.sh
@@ -68,6 +68,9 @@ echo "* Check errno was set to JINUE_EPERM"
 RESULT=`grep -F -A 1 "Attempting to call jinue_receive() on the send-only descriptor." $1`
 echo "$RESULT" | grep -F 'operation not permitted' || fail
 
+echo "* Check client thread started and got the right argument"
+grep -F "Client thread is starting with argument: 0xb01dface" $1 || fail
+
 echo "* Check main thread received message from client thread"
 grep -F "Main thread received message" $1 || fail
 
@@ -110,8 +113,8 @@ echo "$RESULT" | grep -F 'I/O error' || fail
 echo "* Check client thread exited cleanly"
 grep -F "Client thread is exiting." $1 || fail
 
-echo "* Check main thread joined the client thread and retreived its exit value"
-grep -F "Client thread exit value is 42." $1 || fail
+echo "* Check main thread joined the client thread and retrieved its exit value"
+grep -F "Client thread exit value is 0xdeadbeef." $1 || fail
 
 echo "* Check the main thread initiated the reboot"
 grep -F "Main thread is running." $1 || fail

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -18,7 +18,7 @@
 | 9       | [CREATE_ENDPOINT](create-endpoint.md)   | Create IPC Endpoint                  |
 | 10      | [RECEIVE](receive.md)                   | Receive Message                      |
 | 11      | [REPLY](reply.md)                       | Reply to Message                     |
-| 12      | [EXIT_THREAD](exit-thread.md)           | Exit the Current Thread              |
+| 12      | [EXIT_THREAD](exit-thread.md)           | Terminate the Current Thread         |
 | 13      | [MMAP](mmap.md)                         | Map Memory                           |
 | 14      | [CREATE_PROCESS](create-process.md)     | Create Process                       |
 | 15      | [MCLONE](mclone.md)                     | Clone a Memory Mapping               |

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -26,7 +26,8 @@
 | 17      | [CLOSE](close.md)                       | Close a Descriptor                   |
 | 18      | [DESTROY](destroy.md)                   | Destroy a Kernel Object              |
 | 19      | [MINT](mint.md)                         | Mint a Descriptor                    |
-| 20-4095 | -                                       | Reserved                             |
+| 20      | [START_THREAD](start-thread.md)         | Start a Thread                       |
+| 21-4095 | -                                       | Reserved                             |
 | 4096+   | [SEND](send.md)                         | Send Message                         |
 
 #### Reserved Function Numbers

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -27,7 +27,8 @@
 | 18      | [DESTROY](destroy.md)                   | Destroy a Kernel Object              |
 | 19      | [MINT](mint.md)                         | Mint a Descriptor                    |
 | 20      | [START_THREAD](start-thread.md)         | Start a Thread                       |
-| 21-4095 | -                                       | Reserved                             |
+| 21      | [JOIN_THREAD](join-thread.md)           | Wait for a Thread to Exit            |
+| 22-4095 | -                                       | Reserved                             |
 | 4096+   | [SEND](send.md)                         | Send Message                         |
 
 #### Reserved Function Numbers

--- a/doc/syscalls/create-endpoint.md
+++ b/doc/syscalls/create-endpoint.md
@@ -34,8 +34,8 @@ The descriptor number to bind to the new IPC endpoint is set in `arg1`.
 
 ## Return Value
 
-On success, this function returns the descriptor number for the new IPC endpoint
-(in `arg0`). On failure, it returns -1 and an error number is set (in `arg1`).
+On success, this function returns 0 (in `arg0`). On failure, this function
+returns -1 and an error number is set (in `arg1`).
 
 ## Errors
 

--- a/doc/syscalls/create-thread.md
+++ b/doc/syscalls/create-thread.md
@@ -23,12 +23,12 @@ must have the necessary permissions to create a thread in the target process
     31                                                               0
     
     +----------------------------------------------------------------+
-    |                       descriptor number                        |  arg1
+    |                    thread descriptor number                    |  arg1
     +----------------------------------------------------------------+
     31                                                               0
 
     +----------------------------------------------------------------+
-    |                            process                             |  arg2
+    |                    process descriptor number                   |  arg2
     +----------------------------------------------------------------+
     31                                                               0
 

--- a/doc/syscalls/create-thread.md
+++ b/doc/syscalls/create-thread.md
@@ -6,8 +6,8 @@ Create a new thread in a target process and bind it to a thread descriptor.
 
 For this operation to succeed, the descriptor for the target process
 must have the
-[JINUE_PERM_CREATE_THREAD](../include/jinue/shared/asm/permissions.h) and
-[JINUE_PERM_OPEN](../include/jinue/shared/asm/permissions.h) permissions.
+[JINUE_PERM_CREATE_THREAD](../../include/jinue/shared/asm/permissions.h) and
+[JINUE_PERM_OPEN](../../include/jinue/shared/asm/permissions.h) permissions.
 
 ## Arguments
 

--- a/doc/syscalls/create-thread.md
+++ b/doc/syscalls/create-thread.md
@@ -2,7 +2,12 @@
 
 ## Description
 
-Create a new thread in a target process.
+Create a new thread in a target process and bind it to a thread descriptor.
+
+For this operation to succeed, the descriptor for the target process
+must have the
+[JINUE_PERM_CREATE_THREAD](../include/jinue/shared/asm/permissions.h) and
+[JINUE_PERM_OPEN](../include/jinue/shared/asm/permissions.h) permissions.
 
 ## Arguments
 
@@ -10,11 +15,7 @@ Function number (`arg0`) is 4.
 
 The descriptor number to bind to the new thread is set in `arg1`.
 
-The descriptor number for the target process is set in `arg2`. This descriptor
-must have the necessary permissions to create a thread in the target process
-(JINUE_PERM_CREATE_THREAD) and to bind a descriptor in the target process
-(JINUE_PERM_OPEN).
-
+The descriptor number for the target process is set in `arg2`.
 
 ```
     +----------------------------------------------------------------+
@@ -48,5 +49,5 @@ returns -1 and an error number is set (in `arg1`).
 * JINUE_EBADF if the specified descriptor is already in use.
 * JINUE_EBADF if the target process descriptor is invalid, or does not refer to
 a process, or is closed.
-* JINUE_EPERM if the target process descriptor does not have the needed
-permissions.
+* JINUE_EPERM if the specified process descriptor does not have the permissions
+to create a thread and bind a descriptor into the process.

--- a/doc/syscalls/dup.md
+++ b/doc/syscalls/dup.md
@@ -4,10 +4,17 @@
 
 Create a copy of a descriptor from the current process in a target process.
 
-A owner descriptor cannot be duplicated with this (or any) function. A owner
-descriptor is the descriptor that was specified in the call to the function
-that created a kernel resource (e.g. [CREATE_ENDPOINT](create-endpoint.md)) and that
-can be used to [mint](mint.md) other descriptors to that resource.
+For this operation to succeed, the descriptor for the target process
+must have the [JINUE_PERM_OPEN](../include/jinue/shared/asm/permissions.h)
+permission.
+
+A owner descriptor cannot be duplicated with this (or any) function. The owner
+descriptor for a given kernel resource is the original descriptor to which the
+resource was bound when it was created through the relevant system call (e.g.
+[CREATE_ENDPOINT](create-endpoint) for an IPC endpoint). While a owner
+descriptor cannot be duplicated using this function, the [MINT](mint.md)
+function can be used instead to create a new descriptor that refers to the same
+kernel resource and has customized permissions.
 
 ## Arguments
 
@@ -52,3 +59,5 @@ not refer to a process, or is closed.
 * JINUE_EBADF if the specified source descriptor is invalid, or is a owner
 descriptor, or is closed.
 * JINUE_EBADF if the specified destination descriptor is already in use.
+* JINUE_EPERM if the specified process descriptor does not have the permission
+to bind a descriptor into the process.

--- a/doc/syscalls/dup.md
+++ b/doc/syscalls/dup.md
@@ -5,7 +5,7 @@
 Create a copy of a descriptor from the current process in a target process.
 
 For this operation to succeed, the descriptor for the target process
-must have the [JINUE_PERM_OPEN](../include/jinue/shared/asm/permissions.h)
+must have the [JINUE_PERM_OPEN](../../include/jinue/shared/asm/permissions.h)
 permission.
 
 A owner descriptor cannot be duplicated with this (or any) function. The owner

--- a/doc/syscalls/exit-thread.md
+++ b/doc/syscalls/exit-thread.md
@@ -8,6 +8,30 @@ Exit the current thread.
 
 Function number (`arg0`) is 12.
 
+The exit status is set in `arg1`.
+
+```
+    +----------------------------------------------------------------+
+    |                        function = 12                           |  arg0
+    +----------------------------------------------------------------+
+    31                                                               0
+    
+    +----------------------------------------------------------------+
+    |                         exit status                            |  arg1
+    +----------------------------------------------------------------+
+    31                                                               0
+
+    +----------------------------------------------------------------+
+    |                         reserved (0)                           |  arg2
+    +----------------------------------------------------------------+
+    31                                                               0
+
+    +----------------------------------------------------------------+
+    |                         reserved (0)                           |  arg3
+    +----------------------------------------------------------------+
+    31                                                               0
+```
+
 ## Return Value
 
 This function exits the current thread and does not return.
@@ -15,9 +39,3 @@ This function exits the current thread and does not return.
 ## Errors
 
 This function always succeeds.
-
-## Future Direction
-
-The current system call only affects the current thread. It may be changed or
-some other function may be added to allow another thread to be destroyed, in
-which case the thread would be specified using a descriptor.

--- a/doc/syscalls/exit-thread.md
+++ b/doc/syscalls/exit-thread.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Terminate the current thread and make available a pointer-sized argument to any
+Terminate the current thread and make available a pointer-sized value to any
 thread that successfully joins the terminating thread by calling
 [JOIN_THREAD](join-thread.md).
 
@@ -10,7 +10,7 @@ thread that successfully joins the terminating thread by calling
 
 Function number (`arg0`) is 12.
 
-`arg1` is set to value made available to the joining thread.
+The value made available to the joining thread is set in `arg1`.
 
 ```
     +----------------------------------------------------------------+

--- a/doc/syscalls/exit-thread.md
+++ b/doc/syscalls/exit-thread.md
@@ -1,16 +1,12 @@
-# EXIT_THREAD - Exit the Current Thread
+# EXIT_THREAD - Terminate the Current Thread
 
 ## Description
 
-Terminate the current thread and make available a pointer-sized value to any
-thread that successfully joins the terminating thread by calling
-[JOIN_THREAD](join-thread.md).
+Terminate the current thread.
 
 ## Arguments
 
 Function number (`arg0`) is 12.
-
-The value made available to the joining thread is set in `arg1`.
 
 ```
     +----------------------------------------------------------------+
@@ -19,7 +15,7 @@ The value made available to the joining thread is set in `arg1`.
     31                                                               0
     
     +----------------------------------------------------------------+
-    |                         exit value                             |  arg1
+    |                         reserved (0)                           |  arg1
     +----------------------------------------------------------------+
     31                                                               0
 

--- a/doc/syscalls/exit-thread.md
+++ b/doc/syscalls/exit-thread.md
@@ -3,7 +3,8 @@
 ## Description
 
 Terminate the current thread and make available a pointer-sized argument to any
-thread that successfully joins the terminating thread.
+thread that successfully joins the terminating thread by calling
+[JOIN_THREAD](join-thread.md).
 
 ## Arguments
 

--- a/doc/syscalls/exit-thread.md
+++ b/doc/syscalls/exit-thread.md
@@ -2,13 +2,14 @@
 
 ## Description
 
-Exit the current thread.
+Terminate the current thread and make available a pointer-sized argument to any
+thread that successfully joins the terminating thread.
 
 ## Arguments
 
 Function number (`arg0`) is 12.
 
-The exit status is set in `arg1`.
+`arg1` is set to value made available to the joining thread.
 
 ```
     +----------------------------------------------------------------+
@@ -17,7 +18,7 @@ The exit status is set in `arg1`.
     31                                                               0
     
     +----------------------------------------------------------------+
-    |                         exit status                            |  arg1
+    |                         exit value                             |  arg1
     +----------------------------------------------------------------+
     31                                                               0
 
@@ -34,7 +35,7 @@ The exit status is set in `arg1`.
 
 ## Return Value
 
-This function exits the current thread and does not return.
+This function terminates the current thread and does not return.
 
 ## Errors
 

--- a/doc/syscalls/get-thread-local.md
+++ b/doc/syscalls/get-thread-local.md
@@ -35,13 +35,13 @@ Function number (`arg0`) is 7.
 
 ## Return Value
 
-This function returns the address of the thread-local storage in `arg0`. If this
-has not been set for the current thread by a previous call to the Set
-Thread-Local Storage system call, then the return value is zero (i.e. the NULL
-pointer in C).
+This function sets `arg0` to 0 and set the address of the thread-local storage
+in `arg1`. If this has not been set for the current thread by a previous call
+to [SET_THREAD_LOCAL] (set-thread-local.md) then the address set in `arg1` is
+zero (i.e. the NULL pointer in C).
 
-Note that, since this function returns a pointer, it does not follow the usual
-convention whereby a negative return value indicates a failure.
+Note that since this function returns a pointer, it does not follow the usual
+convention where `arg0` is used to return a successful value.
 
 ## Errors
 

--- a/doc/syscalls/join-thread.md
+++ b/doc/syscalls/join-thread.md
@@ -2,17 +2,20 @@
 
 ## Description
 
-Wait for a thread to terminate, if it hasn't already. The target thread must
-have been started with [START_THREAD](start-thread.md) and must not be the
-calling thread. Furthermore, this function must be called at most once on a
-given thread since it has been started.
+Wait for a thread to terminate, if it hasn't already.
+
+The target thread must have been started with [START_THREAD](start-thread.md)
+and must not be the calling thread. Furthermore, this function must be called
+at most once on a given thread since it has been started.
+
+For this operation to succeed, the thread descriptor must have the
+[JINUE_PERM_JOIN](../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 
 Function number (`arg0`) is 21.
 
-The descriptor number for the joined thread is set in `arg1`. This descriptor
-must have the necessary permissions (JINUE_PERM_JOIN).
+The descriptor number for the thread is set in `arg1`.
 
 ```
     +----------------------------------------------------------------+
@@ -43,9 +46,9 @@ returns -1 and an error number is set (in `arg1`).
 
 ## Errors
 
-* JINUE_EBADF if the specified descriptor is invalid, or does not refer to a
+* JINUE_EBADF if the thread descriptor is invalid, or does not refer to a
 thread, or is closed.
-* JINUE_EPERM if the target thread descriptor does not have the needed
-permissions.
 * JINUE_ESRCH if the thread has not been started or has already beed joined.
 * JINUE_EDEADLK if a thread attempts to join itself.
+* JINUE_EPERM if the specified thread descriptor does not have the permission
+to join the thread.

--- a/doc/syscalls/join-thread.md
+++ b/doc/syscalls/join-thread.md
@@ -9,7 +9,7 @@ and must not be the calling thread. Furthermore, this function must be called
 at most once on a given thread since it has been started.
 
 For this operation to succeed, the thread descriptor must have the
-[JINUE_PERM_JOIN](../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_JOIN](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 

--- a/doc/syscalls/join-thread.md
+++ b/doc/syscalls/join-thread.md
@@ -2,9 +2,10 @@
 
 ## Description
 
-Wait for a thread to terminate, if it hasn't already, and then retrieve the
-pointer-sized value this thread made available when it called
-[EXIT_THREAD](exit-thread.md).
+Wait for a thread to terminate, if it hasn't already. The target thread must
+have been started with [START_THREAD](start-thread.md) and must not be the
+calling thread. Furthermore, this function must be called at most once on a
+given thread since it has been started.
 
 ## Arguments
 
@@ -37,13 +38,8 @@ must have the necessary permissions (JINUE_PERM_JOIN).
 
 ## Return Value
 
-On success, this function sets `arg0` to 0 and set the value the joined thread
-made available when it called [EXIT_THREAD](exit-thread.md) in `arg1`.
-
-On failure, this function sets `arg0` to -1 and an error number in `arg1`.
-
-Note that since this function returns a pointer, it does not follow the usual
-convention where `arg0` is used to return a successful value.
+On success, this function returns 0 (in `arg0`). On failure, this function
+returns -1 and an error number is set (in `arg1`).
 
 ## Errors
 
@@ -51,3 +47,5 @@ convention where `arg0` is used to return a successful value.
 thread, or is closed.
 * JINUE_EPERM if the target thread descriptor does not have the needed
 permissions.
+* JINUE_ESRCH if the thread has not been started or has already beed joined.
+* JINUE_EDEADLK if a thread attempts to join itself.

--- a/doc/syscalls/join-thread.md
+++ b/doc/syscalls/join-thread.md
@@ -1,23 +1,21 @@
-# START_THREAD - Start a Thread
+# START_THREAD - Wait for a Thread to Exit
 
 ## Description
 
-Set the entry point and stack address on a non-running thread and allow it to
-start running.
+Wait for a thread to terminate, if it hasn't already, and then retrieve the
+pointer-sized value this thread made available when it called
+[EXIT_THREAD](exit-thread.md).
 
 ## Arguments
 
-Function number (`arg0`) is 20.
+Function number (`arg0`) is 21.
 
-The descriptor number for the target thread is set in `arg1`. This descriptor
-must have the necessary permissions (JINUE_PERM_START).
-
-The address where code execution will start is set in `arg2` and the
-value of the initial stack pointer is set in `arg3`.
+The descriptor number for the joined thread is set in `arg1`. This descriptor
+must have the necessary permissions (JINUE_PERM_JOIN).
 
 ```
     +----------------------------------------------------------------+
-    |                         function = 20                          |  arg0
+    |                         function = 22                          |  arg0
     +----------------------------------------------------------------+
     31                                                               0
     
@@ -27,31 +25,29 @@ value of the initial stack pointer is set in `arg3`.
     31                                                               0
 
     +----------------------------------------------------------------+
-    |                   code entry point address                     |  arg2
+    |                          reserved (0)                          |  arg2
     +----------------------------------------------------------------+
     31                                                               0
 
     +----------------------------------------------------------------+
-    |                      user stack address                        |  arg3
+    |                          reserved (0)                          |  arg3
     +----------------------------------------------------------------+
     31                                                               0
 ```
 
 ## Return Value
 
-On success, this function returns 0 (in `arg0`). On failure, this function
-returns -1 and an error number is set (in `arg1`).
+On success, this function sets `arg0` to 0 and set the value the joined thread
+made available when it called [EXIT_THREAD](exit-thread.md) in `arg1`.
+
+On failure, this function sets `arg0` to -1 and an error number in `arg1`.
+
+Note that since this function returns a pointer, it does not follow the usual
+convention where `arg0` is used to return a successful value.
 
 ## Errors
 
-* JINUE_EINVAL if the code entry point is set to a kernel address.
-* JINUE_EINVAL if the user stack address is set to a kernel address.
 * JINUE_EBADF if the specified descriptor is invalid, or does not refer to a
 thread, or is closed.
 * JINUE_EPERM if the target thread descriptor does not have the needed
 permissions.
-
-## Future Direction
-
-This system call will be modified to allow a pointer argument to be passed to
-the started thread.

--- a/doc/syscalls/join-thread.md
+++ b/doc/syscalls/join-thread.md
@@ -1,4 +1,4 @@
-# START_THREAD - Wait for a Thread to Exit
+# JOIN_THREAD - Wait for a Thread to Exit
 
 ## Description
 
@@ -15,7 +15,7 @@ must have the necessary permissions (JINUE_PERM_JOIN).
 
 ```
     +----------------------------------------------------------------+
-    |                         function = 22                          |  arg0
+    |                         function = 21                          |  arg0
     +----------------------------------------------------------------+
     31                                                               0
     

--- a/doc/syscalls/mclone.md
+++ b/doc/syscalls/mclone.md
@@ -4,6 +4,9 @@
 
 Clone a contiguous memory mapping from one process to another.
 
+For this operation to succeed, the destination process descriptor must have the
+[JINUE_PERM_MAP](../include/jinue/shared/asm/permissions.h) permission.
+
 ## Arguments
 
 Function number (`arg0`) is 15.
@@ -80,3 +83,5 @@ belongs to the kernel.
 to a process, or is closed.
 * JINUE_EIO if either process no longer exists.
 * JINUE_ENOMEM if not enough memory is available to allocate needed page tables.
+* JINUE_EPERM if the destination process descriptor does not have the
+permission to map memory into the process.

--- a/doc/syscalls/mclone.md
+++ b/doc/syscalls/mclone.md
@@ -5,7 +5,7 @@
 Clone a contiguous memory mapping from one process to another.
 
 For this operation to succeed, the destination process descriptor must have the
-[JINUE_PERM_MAP](../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_MAP](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 

--- a/doc/syscalls/mint.md
+++ b/doc/syscalls/mint.md
@@ -2,12 +2,50 @@
 
 ## Description
 
-Create a descriptor referencing a kernel resource with specified cookie and
-permissions.
+Create a descriptor referencing a kernel resource with specified permissions
+and cookie.
 
-In order to use this function, the owner descriptor for the resource must be
-specified. The owner descriptor is the descriptor that was specified in the
-call to the function that created the resource (e.g. CREATE_ENDPOINT).
+In order to use this function, the owner descriptor for a kernel resource must
+passed as an argument. The owner descriptor for a given kernel resource is the
+original descriptor to which the resource was bound when it was created through
+the relevant system call (e.g. [CREATE_ENDPOINT](create-endpoint) for an IPC
+endpoint). This function binds the same object to a new descriptor with
+customized permissions and cookie.
+
+The permissions that can be set on a descriptor depends on the type of kernel
+object it refers to. See the
+[flag definitions](../include/jinue/shared/asm/permissions.h) for the numerical
+values of the various permission flags.
+
+If the owner descriptor refers to an IPC endpoint, the following permission
+flags can be specified:
+
+| Name                  | Description           |
+|-----------------------|-----------------------|
+| JINUE_PERM_SEND       | Send messages         |
+| JINUE_PERM_RECEIVE    | Receive messages      |
+
+If the owner descriptor refers to a process, the following permission flags can
+be specified:
+
+| Name                      | Description                               |
+|---------------------------|-------------------------------------------|
+| JINUE_PERM_CREATE_THREAD  | Create a thread                           |
+| JINUE_PERM_MAP            | Map memory into the virtual address space |
+| JINUE_PERM_OPEN           | Bind a descriptor                         |
+
+If the owner descriptor refers to a thread, the following permission flags can
+be specified:
+
+| Name              | Description                       |
+|-------------------|-----------------------------------|
+| JINUE_PERM_START  | Start the thread                  |
+| JINUE_PERM_JOIN   | Wait for the thread to terminate  |
+
+Other permission flags are reserved.
+
+For this operation to succeed, the descriptor for the target process must have
+the [JINUE_PERM_OPEN](../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 
@@ -47,23 +85,13 @@ The mint arguments structure contains the following fields:
 descriptor.
 * `fd` descriptor number in the target process in which to place the new
 descriptor.
-* `perms` the permission flags of the new descriptor (see below).
+* `perms` the permission flags of the new descriptor, which must describe a
+permissions set appropriate for the type of kernel object the descriptor refers
+to. See the [flag definitions](../include/jinue/shared/asm/permissions.h) for
+the numerical values of the permission flags.
 * `cookie` the cookie of the new descriptor. This parameter is only meaningful
 for references to IPC endpoints and can be set to anything, including zero, for
 other resource types.
-
-`perms` must be set to the bitwise or of permission flags that are appropriate
-for the type of kernel object to which the owner descriptor refers.
-
-If the owner descriptor refers to an IPC endpoint, the following permission
-flags can be specified:
-
-| Value | Name                  | Description                       |
-|-------|-----------------------|-----------------------------------|
-| 1     | JINUE_PERM_SEND       | Can be used to send messages      |
-| 2     | JINUE_PERM_RECEIVE    | Can be used to receive messages   |
-
-Other permission flags are reserved.
 
 ## Return Value
 
@@ -79,4 +107,8 @@ appropriate for the type of kernel object to which the owner descriptor refers.
 to a process or is closed.
 * JINUE_EBADF if the descriptor specified in the `fd` argument is invalid or is
 already in use.
-* JINUE_EPERM if the specified descriptor is not the owner descriptor.
+* JINUE_EPERM if the specified owner descriptor is not the owner descriptor of
+a kernel resource.
+* JINUE_EPERM if the specified process descriptor does not have the permission
+to bind a descriptor into the process.
+

--- a/doc/syscalls/mint.md
+++ b/doc/syscalls/mint.md
@@ -14,8 +14,8 @@ customized permissions and cookie.
 
 The permissions that can be set on a descriptor depends on the type of kernel
 object it refers to. See the
-[flag definitions](../include/jinue/shared/asm/permissions.h) for the numerical
-values of the various permission flags.
+[flag definitions](../../include/jinue/shared/asm/permissions.h) for the
+numerical values of the various permission flags.
 
 If the owner descriptor refers to an IPC endpoint, the following permission
 flags can be specified:
@@ -45,7 +45,7 @@ be specified:
 Other permission flags are reserved.
 
 For this operation to succeed, the descriptor for the target process must have
-the [JINUE_PERM_OPEN](../include/jinue/shared/asm/permissions.h) permission.
+the [JINUE_PERM_OPEN](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 
@@ -87,8 +87,8 @@ descriptor.
 descriptor.
 * `perms` the permission flags of the new descriptor, which must describe a
 permissions set appropriate for the type of kernel object the descriptor refers
-to. See the [flag definitions](../include/jinue/shared/asm/permissions.h) for
-the numerical values of the permission flags.
+to. See the [flag definitions](../../include/jinue/shared/asm/permissions.h)
+for the numerical values of the permission flags.
 * `cookie` the cookie of the new descriptor. This parameter is only meaningful
 for references to IPC endpoints and can be set to anything, including zero, for
 other resource types.

--- a/doc/syscalls/mmap.md
+++ b/doc/syscalls/mmap.md
@@ -4,6 +4,9 @@
 
 Map a contiguous block of memory into the address space of a process.
 
+For this operation to succeed, the process descriptor must have the
+[JINUE_PERM_MAP](../include/jinue/shared/asm/permissions.h) permission.
+
 ## Arguments
 
 Function number (`arg0`) is 13.
@@ -66,15 +69,19 @@ returns -1 and an error number is set (in `arg1`).
 
 ## Errors
 
-* JINUE_EINVAL if `addr`, `length` and/or `paddr` are not aligned to a page boundary.
-* JINUE_EINVAL if any part of the mmap arguments structure as specified by `arg2`
-belongs to the kernel.
-* JINUE_EINVAL if `prot` is not `JINUE_PROT_NONE` or a bitwise or combination of
-`JINUE_PROT_READ`, `JINUE_PROT_WRITE` and/or `JINUE_PROT_EXEC`.
+* JINUE_EINVAL if `addr`, `length` and/or `paddr` are not aligned to a page
+boundary.
+* JINUE_EINVAL if any part of the mmap arguments structure as specified by
+`arg2` belongs to the kernel.
+* JINUE_EINVAL if `prot` is not `JINUE_PROT_NONE` or a bitwise or combination
+of `JINUE_PROT_READ`, `JINUE_PROT_WRITE` and/or `JINUE_PROT_EXEC`.
 * JINUE_EBADF if the specified descriptor is invalid, or does not refer to a
 process, or is closed.
 * JINUE_EIO if the process no longer exists.
-* JINUE_ENOMEM if not enough memory is available to allocate needed page tables.
+* JINUE_ENOMEM if not enough memory is available to allocate needed page
+tables.
+* JINUE_EPERM if the process descriptor does not have the permission to map
+memory into the process.
 
 ## Future Direction
 

--- a/doc/syscalls/mmap.md
+++ b/doc/syscalls/mmap.md
@@ -5,7 +5,7 @@
 Map a contiguous block of memory into the address space of a process.
 
 For this operation to succeed, the process descriptor must have the
-[JINUE_PERM_MAP](../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_MAP](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 

--- a/doc/syscalls/receive.md
+++ b/doc/syscalls/receive.md
@@ -17,7 +17,7 @@ argument:
   when [REPLY](reply.md)ing to the sender.
 
 For this operation to succeed, the IPC endpoint descriptor must have the
-[JINUE_PERM_RECEIVE](../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_RECEIVE](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 

--- a/doc/syscalls/receive.md
+++ b/doc/syscalls/receive.md
@@ -16,6 +16,9 @@ argument:
 * `reply_max_size` is set to the maximum size of the reply that can be sent back
   when [REPLY](reply.md)ing to the sender.
 
+For this operation to succeed, the IPC endpoint descriptor must have the
+[JINUE_PERM_RECEIVE](../include/jinue/shared/asm/permissions.h) permission.
+
 ## Arguments
 
 Function number (`arg0`) is 10.

--- a/doc/syscalls/send.md
+++ b/doc/syscalls/send.md
@@ -5,6 +5,9 @@
 Send a message to an IPC endpoint. This call blocks until the message is
 received and replied to.
 
+For this operation to succeed, the IPC endpoint descriptor must have the
+[JINUE_PERM_SEND](../include/jinue/shared/asm/permissions.h) permission.
+
 ## Arguments
 
 The function number, which must be at least 4096, is set in `arg0`. The function

--- a/doc/syscalls/send.md
+++ b/doc/syscalls/send.md
@@ -6,7 +6,7 @@ Send a message to an IPC endpoint. This call blocks until the message is
 received and replied to.
 
 For this operation to succeed, the IPC endpoint descriptor must have the
-[JINUE_PERM_SEND](../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_SEND](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 

--- a/doc/syscalls/start-thread.md
+++ b/doc/syscalls/start-thread.md
@@ -1,24 +1,23 @@
-# CREATE_THREAD - Create a Thread
+# START_THREAD - Start a Thread
 
 ## Description
 
-Create a new thread in a target process.
+Set the entry point and stack address on a non-running thread and allow it to
+start running.
 
 ## Arguments
 
-Function number (`arg0`) is 4.
+Function number (`arg0`) is 20.
 
-The descriptor number to bind to the new thread is set in `arg1`.
+The descriptor number for the target thread is set in `arg1`. This descriptor
+must have the necessary permissions (JINUE_PERM_START).
 
-The descriptor number for the target process is set in `arg2`. This descriptor
-must have the necessary permissions to create a thread in the target process
-(JINUE_PERM_CREATE_THREAD) and to bind a descriptor in the target process
-(JINUE_PERM_OPEN).
-
+The address where code execution will start is set in `arg2` and the
+value of the initial stack pointer is set in `arg3`.
 
 ```
     +----------------------------------------------------------------+
-    |                         function = 4                           |  arg0
+    |                         function = 20                          |  arg0
     +----------------------------------------------------------------+
     31                                                               0
     
@@ -28,12 +27,12 @@ must have the necessary permissions to create a thread in the target process
     31                                                               0
 
     +----------------------------------------------------------------+
-    |                            process                             |  arg2
+    |                   code entry point address                     |  arg2
     +----------------------------------------------------------------+
     31                                                               0
 
     +----------------------------------------------------------------+
-    |                         reserved (0)                           |  arg3
+    |                      user stack address                        |  arg3
     +----------------------------------------------------------------+
     31                                                               0
 ```
@@ -45,8 +44,14 @@ returns -1 and an error number is set (in `arg1`).
 
 ## Errors
 
-* JINUE_EBADF if the specified descriptor is already in use.
-* JINUE_EBADF if the target process descriptor is invalid, or does not refer to
-a process, or is closed.
-* JINUE_EPERM if the target process descriptor does not have the needed
+* JINUE_EINVAL if the code entry point is set to a kernel address.
+* JINUE_EINVAL if the user stack address is set to a kernel address.
+* JINUE_EBADF if the specified descriptor is invalid, or does not refer to a
+thread, or is closed.
+* JINUE_EPERM if the target thread descriptor does not have the needed
 permissions.
+
+## Future Direction
+
+This system call will be modified to allow a pointer argument to be passed to
+the started thread.

--- a/doc/syscalls/start-thread.md
+++ b/doc/syscalls/start-thread.md
@@ -2,15 +2,17 @@
 
 ## Description
 
-Set the entry point and stack address on a non-running thread and allow it to
-start running.
+Set the entry point and stack address on a non-running thread specified by a
+descriptor number and then start the thread.
+
+For this operation to succeed, the thread descriptor must have the
+[JINUE_PERM_START](../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 
 Function number (`arg0`) is 20.
 
-The descriptor number for the target thread is set in `arg1`. This descriptor
-must have the necessary permissions (JINUE_PERM_START).
+The descriptor number for the target thread is set in `arg1`.
 
 The address where code execution will start is set in `arg2` and the
 value of the initial stack pointer is set in `arg3`.
@@ -27,7 +29,7 @@ value of the initial stack pointer is set in `arg3`.
     31                                                               0
 
     +----------------------------------------------------------------+
-    |                   code entry point address                     |  arg2
+    |                    code entry point address                    |  arg2
     +----------------------------------------------------------------+
     31                                                               0
 
@@ -46,10 +48,11 @@ returns -1 and an error number is set (in `arg1`).
 
 * JINUE_EINVAL if the code entry point is set to a kernel address.
 * JINUE_EINVAL if the user stack address is set to a kernel address.
-* JINUE_EBADF if the specified descriptor is invalid, or does not refer to a
+* JINUE_EBADF if the thread descriptor is invalid, or does not refer to a
 thread, or is closed.
-* JINUE_EPERM if the target thread descriptor does not have the needed
-permissions.
+* JINUE_EPERM if the thread descriptor does not have the permission to start
+the thread.
+* JINUE_EBUSY if the thread is already running.
 
 ## Future Direction
 

--- a/doc/syscalls/start-thread.md
+++ b/doc/syscalls/start-thread.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Set the entry point and stack address on a non-running thread specified by a
+Set the entry point and stack address of a non-running thread specified by a
 descriptor number and then start the thread.
 
 For this operation to succeed, the thread descriptor must have the
@@ -53,8 +53,3 @@ thread, or is closed.
 * JINUE_EPERM if the thread descriptor does not have the permission to start
 the thread.
 * JINUE_EBUSY if the thread is already running.
-
-## Future Direction
-
-This system call will be modified to allow a pointer argument to be passed to
-the started thread.

--- a/doc/syscalls/start-thread.md
+++ b/doc/syscalls/start-thread.md
@@ -6,7 +6,7 @@ Set the entry point and stack address on a non-running thread specified by a
 descriptor number and then start the thread.
 
 For this operation to succeed, the thread descriptor must have the
-[JINUE_PERM_START](../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_START](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 

--- a/include/errno.h
+++ b/include/errno.h
@@ -56,4 +56,6 @@ extern int errno;
 
 #define ENOTSUP     JINUE_ENOTSUP
 
+#define EBUSY       JINUE_EBUSY
+
 #endif

--- a/include/errno.h
+++ b/include/errno.h
@@ -58,4 +58,8 @@ extern int errno;
 
 #define EBUSY       JINUE_EBUSY
 
+#define ESRCH       JINUE_ESRCH
+
+#define EDEADLK     JINUE_EDEADLK
+
 #endif

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -56,7 +56,7 @@ int jinue_create_thread(int fd, int process, int *perrno);
 
 void jinue_yield_thread(void);
 
-void jinue_exit_thread(void);
+void jinue_exit_thread(int status);
 
 void jinue_putc(char c);
 

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -52,7 +52,7 @@ void jinue_set_thread_local(void *addr, size_t size);
 
 void *jinue_get_thread_local(void);
 
-int jinue_create_thread(int process, void (*entry)(), void *stack, int *perrno);
+int jinue_create_thread(int fd, int process, int *perrno);
 
 void jinue_yield_thread(void);
 
@@ -108,5 +108,7 @@ int jinue_mint(
         int          perms,
         uintptr_t    cookie,
         int         *perrno);
+
+int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno);
 
 #endif

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -60,7 +60,7 @@ int jinue_create_thread(int fd, int process, int *perrno);
 
 void jinue_yield_thread(void);
 
-void jinue_exit_thread(void *value_ptr);
+void jinue_exit_thread(void);
 
 void jinue_putc(char c);
 
@@ -115,6 +115,6 @@ int jinue_mint(
 
 int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno);
 
-int jinue_join_thread(int fd, void **exit_value, int *perrno);
+int jinue_join_thread(int fd, int *perrno);
 
 #endif

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -46,11 +46,13 @@
 
 int jinue_init(int implementation, int *perrno);
 
+uintptr_t jinue_syscall(jinue_syscall_args_t *args);
+
 void jinue_reboot(void);
 
 void jinue_set_thread_local(void *addr, size_t size);
 
-void *jinue_get_thread_local(void);
+int jinue_get_thread_local(void **thread_local);
 
 int jinue_create_thread(int fd, int process, int *perrno);
 
@@ -110,5 +112,7 @@ int jinue_mint(
         int         *perrno);
 
 int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno);
+
+int jinue_join_thread(int fd, void **exit_value, int *perrno);
 
 #endif

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -48,6 +48,8 @@ int jinue_init(int implementation, int *perrno);
 
 uintptr_t jinue_syscall(jinue_syscall_args_t *args);
 
+void jinue_thread_entry(void);
+
 void jinue_reboot(void);
 
 void jinue_set_thread_local(void *addr, size_t size);

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -56,7 +56,7 @@ int jinue_create_thread(int fd, int process, int *perrno);
 
 void jinue_yield_thread(void);
 
-void jinue_exit_thread(int status);
+void jinue_exit_thread(void *value_ptr);
 
 void jinue_putc(char c);
 

--- a/include/jinue/shared/asm/errno.h
+++ b/include/jinue/shared/asm/errno.h
@@ -65,4 +65,10 @@
 /** device or resource busy */
 #define JINUE_EBUSY     11
 
+/** no such process */
+#define JINUE_ESRCH     12
+
+/** resource deadlock would occur */
+#define JINUE_EDEADLK   13
+
 #endif

--- a/include/jinue/shared/asm/errno.h
+++ b/include/jinue/shared/asm/errno.h
@@ -62,4 +62,7 @@
 /** not supported */
 #define JINUE_ENOTSUP   10
 
+/** device or resource busy */
+#define JINUE_EBUSY     11
+
 #endif

--- a/include/jinue/shared/asm/permissions.h
+++ b/include/jinue/shared/asm/permissions.h
@@ -32,18 +32,25 @@
 #ifndef _JINUE_SHARED_ASM_PERMISSIONS_H
 #define _JINUE_SHARED_ASM_PERMISSIONS_H
 
+/** send a message */
 #define JINUE_PERM_SEND             (1<<0)
 
+/** receive a message */
 #define JINUE_PERM_RECEIVE          (1<<1)
 
+/** map memory into a process */
 #define JINUE_PERM_MAP              (1<<2)
 
+/** bind a descriptor into a process */
 #define JINUE_PERM_OPEN             (1<<3)
 
+/** create a thread within a process */
 #define JINUE_PERM_CREATE_THREAD    (1<<4)
 
+/** start a thread */
 #define JINUE_PERM_START            (1<<5)
 
+/** join a thread */
 #define JINUE_PERM_JOIN             (1<<6)
 
 #endif

--- a/include/jinue/shared/asm/permissions.h
+++ b/include/jinue/shared/asm/permissions.h
@@ -40,8 +40,8 @@
 
 #define JINUE_PERM_OPEN             (1<<3)
 
-#define JINUE_PERM_CLOSE            (1<<4)
+#define JINUE_PERM_CREATE_THREAD    (1<<4)
 
-#define JINUE_PERM_CREATE_THREAD    (1<<5)
+#define JINUE_PERM_START            (1<<5)
 
 #endif

--- a/include/jinue/shared/asm/permissions.h
+++ b/include/jinue/shared/asm/permissions.h
@@ -44,4 +44,6 @@
 
 #define JINUE_PERM_START            (1<<5)
 
+#define JINUE_PERM_JOIN             (1<<6)
+
 #endif

--- a/include/jinue/shared/asm/syscalls.h
+++ b/include/jinue/shared/asm/syscalls.h
@@ -89,6 +89,9 @@
 /** start a thread */
 #define JINUE_SYS_START_THREAD          20
 
+/** wait for a thread to exit */
+#define JINUE_SYS_JOIN_THREAD           21
+
 /** start of function numbers for user space messages */
 #define JINUE_SYS_USER_BASE             4096
 

--- a/include/jinue/shared/asm/syscalls.h
+++ b/include/jinue/shared/asm/syscalls.h
@@ -86,6 +86,9 @@
 /** create a descriptor with specified cookie and permissions */
 #define JINUE_SYS_MINT                  19
 
+/** start a thread */
+#define JINUE_SYS_START_THREAD          20
+
 /** start of function numbers for user space messages */
 #define JINUE_SYS_USER_BASE             4096
 

--- a/include/jinue/threads.h
+++ b/include/jinue/threads.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Philippe Aubertin.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the author nor the names of other contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _JINUE_THREADS_H
+#define _JINUE_THREADS_H
+
+#include <stddef.h>
+
+typedef struct jinue_thread *jinue_thread_t;
+
+int jinue_thread_init(jinue_thread_t *thread, int fd, size_t stacksize);
+
+int jinue_thread_start(jinue_thread_t thread, void *(*start_routine)(void*), void *arg);
+
+int jinue_thread_join(jinue_thread_t thread, void **value_ptr);
+
+int jinue_thread_destroy(jinue_thread_t thread);
+
+#endif

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -46,13 +46,13 @@ int destroy(int fd);
 
 int dup(int process_fd, int src, int dest);
 
-void exit_thread(void *exit_value);
+void exit_thread(void);
 
 void *get_thread_local(void);
 
 int get_user_memory(const jinue_buffer_t *buffer);
 
-int join_thread(int fd, void **exit_value);
+int join_thread(int fd);
 
 int mclone(int src, int dest, const jinue_mclone_args_t *args);
 

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -46,7 +46,7 @@ int destroy(int fd);
 
 int dup(int process_fd, int src, int dest);
 
-void exit_thread(int status);
+void exit_thread(void *exit_value);
 
 void *get_thread_local(void);
 

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -40,7 +40,7 @@ int create_endpoint(int fd);
 
 int create_process(int fd);
 
-int create_thread(int  process_fd, const thread_params_t *params);
+int create_thread(int process_fd, const thread_params_t *params);
 
 int destroy(int fd);
 

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -46,7 +46,7 @@ int destroy(int fd);
 
 int dup(int process_fd, int src, int dest);
 
-void exit_thread(void);
+void exit_thread(int status);
 
 void *get_thread_local(void);
 

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -52,6 +52,8 @@ void *get_thread_local(void);
 
 int get_user_memory(const jinue_buffer_t *buffer);
 
+int join_thread(int fd, void **exit_value);
+
 int mclone(int src, int dest, const jinue_mclone_args_t *args);
 
 int mint(int owner, const jinue_mint_args_t *mint_args);

--- a/include/kernel/domain/entities/thread.h
+++ b/include/kernel/domain/entities/thread.h
@@ -36,15 +36,17 @@
 
 extern const object_type_t *object_type_thread;
 
-thread_t *construct_thread(process_t *process, const thread_params_t *params);
+thread_t *construct_thread(process_t *process);
 
 void free_thread(thread_t *thread);
-        
+
+void prepare_thread(thread_t *thread, const thread_params_t *params);
+       
 void ready_thread(thread_t *thread);
 
 void switch_to_thread(thread_t *thread, bool blocked);
 
-void start_first_thread(void);
+void start_first_thread(thread_t *thread);
 
 void yield_current_thread(void);
 

--- a/include/kernel/domain/entities/thread.h
+++ b/include/kernel/domain/entities/thread.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Philippe Aubertin.
+ * Copyright (C) 2019-2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/kernel/domain/entities/thread.h
+++ b/include/kernel/domain/entities/thread.h
@@ -38,8 +38,6 @@ extern const object_type_t *object_type_thread;
 
 thread_t *construct_thread(process_t *process);
 
-void free_thread(thread_t *thread);
-
 void prepare_thread(thread_t *thread, const thread_params_t *params);
        
 void ready_thread(thread_t *thread);
@@ -52,7 +50,7 @@ void yield_current_thread(void);
 
 void block_current_thread(void);
 
-void exit_current_thread(void);
+void switch_from_exiting_thread(thread_t *current);
 
 void set_thread_local_storage(thread_t *thread, addr_t addr, size_t size);
 

--- a/include/kernel/domain/services/exec.h
+++ b/include/kernel/domain/services/exec.h
@@ -36,6 +36,7 @@
 
 void exec(
         process_t           *process,
+        thread_t            *thread,
         const exec_file_t   *exec_file,
         const char          *argv0,
         const char          *cmdline);

--- a/include/kernel/domain/services/ipc.h
+++ b/include/kernel/domain/services/ipc.h
@@ -45,6 +45,6 @@ int receive_message(ipc_endpoint_t *endpoint, thread_t *receiver,jinue_message_t
 
 int reply_to_message(thread_t *replier, const jinue_message_t *message);
 
-void abort_message(thread_t *thread, int errno);
+void abort_message(thread_t *thread);
 
 #endif

--- a/include/kernel/machine/thread.h
+++ b/include/kernel/machine/thread.h
@@ -36,7 +36,7 @@
 
 thread_t *get_current_thread(void);
 
-void machine_init_thread(thread_t *thread, const thread_params_t *params);
+void machine_prepare_thread(thread_t *thread, const thread_params_t *params);
 
 thread_t *machine_alloc_thread(void);
 

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -106,7 +106,6 @@ struct thread_t {
     machine_thread_t         thread_ctx;
     jinue_node_t             thread_list;
     thread_state_t           state;
-    void                    *exit_value;
     process_t               *process;
     struct thread_t         *sender;
     struct thread_t         *joined;

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -106,7 +106,7 @@ struct thread_t {
     machine_thread_t         thread_ctx;
     jinue_node_t             thread_list;
     thread_state_t           state;
-    int                      exit_status;
+    void                    *exit_value;
     process_t               *process;
     struct thread_t         *sender;
     addr_t                   local_storage_addr;

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -109,6 +109,7 @@ struct thread_t {
     void                    *exit_value;
     process_t               *process;
     struct thread_t         *sender;
+    struct thread_t         *joined;
     addr_t                   local_storage_addr;
     size_t                   local_storage_size;
     size_t                   recv_buffer_size;

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -94,14 +94,23 @@ typedef struct {
     descriptor_t    descriptors[PROCESS_MAX_DESCRIPTORS];
 } process_t;
 
+typedef enum {
+    THREAD_STATE_ZOMBIE,
+    THREAD_STATE_READY,
+    THREAD_STATE_RUNNING,
+    THREAD_STATE_BLOCKED
+} thread_state_t;
+
 struct thread_t {
     object_header_t          header;
     machine_thread_t         thread_ctx;
     jinue_node_t             thread_list;
+    thread_state_t           state;
+    int                      exit_status;
     process_t               *process;
+    struct thread_t         *sender;
     addr_t                   local_storage_addr;
     size_t                   local_storage_size;
-    struct thread_t         *sender;
     size_t                   recv_buffer_size;
     int                      message_errno;
     uintptr_t                message_function;

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -78,6 +78,7 @@ sources.kernel.c = \
 	application/syscalls/reply.c \
 	application/syscalls/send.c \
 	application/syscalls/set_thread_local.c \
+	application/syscalls/start_thread.c \
 	application/syscalls/yield_thread.c \
 	application/kmain.c \
 	domain/alloc/page_alloc.c \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -69,6 +69,7 @@ sources.kernel.c = \
 	application/syscalls/exit_thread.c \
 	application/syscalls/get_thread_local.c \
 	application/syscalls/get_user_memory.c \
+	application/syscalls/join_thread.c \
 	application/syscalls/mint.c \
 	application/syscalls/mmap.c \
 	application/syscalls/mclone.c \

--- a/kernel/application/kmain.c
+++ b/kernel/application/kmain.c
@@ -93,18 +93,31 @@ void kmain(const char *cmdline) {
 
     switch_to_process(process);
 
+    /* create user space loader main thread */
+    thread_t *thread = construct_thread(process);
+
+    if(thread == NULL) {
+        panic("Could not create initial thread.");
+    }
+
     /* load user space loader binary */
     exec_file_t loader;
     machine_get_loader(&loader);
 
-    exec(process, &loader, "jinue-userspace-loader", cmdline);
+    exec(
+        process,
+        thread,
+        &loader,
+        "jinue-userspace-loader",
+        cmdline
+    );
 
     /* This should be the last thing the kernel prints before passing control
      * to the user space loader. */
     info("---");
 
-    /* Start first thread */
-    start_first_thread();
+    /* Start first thread. */
+    start_first_thread(thread);
 
     /* should never happen */
     panic("start_first_thread() returned in kmain()");

--- a/kernel/application/syscalls/create_endpoint.c
+++ b/kernel/application/syscalls/create_endpoint.c
@@ -68,5 +68,5 @@ int create_endpoint(int fd) {
 
     open_object(&endpoint->header, desc);
 
-    return fd;
+    return 0;
 }

--- a/kernel/application/syscalls/create_thread.c
+++ b/kernel/application/syscalls/create_thread.c
@@ -36,7 +36,7 @@
 #include <kernel/domain/entities/process.h>
 #include <kernel/domain/entities/thread.h>
 
-int create_thread(int  process_fd, const thread_params_t *params) {
+int create_thread(int process_fd, const thread_params_t *params) {
     descriptor_t *desc;
     int status = dereference_object_descriptor(&desc, get_current_process(), process_fd);
 
@@ -54,8 +54,16 @@ int create_thread(int  process_fd, const thread_params_t *params) {
         return -JINUE_EPERM;
     }
 
-    const thread_t *thread = construct_thread(process, params);
+    thread_t *thread = construct_thread(process);
+
+    if(thread == 0) {
+        return -JINUE_ENOMEM;
+    }
+
+    prepare_thread(thread, params);
+
+    ready_thread(thread);
 
     /** TODO associate new thread to a free descriptor */
-    return (thread == NULL) ? -JINUE_EAGAIN : 0;
+    return 0;
 }

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -45,6 +45,10 @@ void exit_thread(void *exit_value) {
 
     thread->exit_value = exit_value;
 
+    if(thread->joined != NULL) {
+        ready_thread(thread->joined);
+    }
+
     /* When we started the thread in start_thread(), we incremented the
      * reference count on it to ensure it continues running even if all
      * descriptors that reference it are closed. This call here will safely

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -35,7 +35,7 @@
 #include <kernel/domain/services/ipc.h>
 #include <kernel/machine/thread.h>
 
-void exit_thread(int status) {
+void exit_thread(void *exit_value) {
     thread_t *thread = get_current_thread();
 
     if(thread->sender != NULL) {
@@ -43,7 +43,7 @@ void exit_thread(int status) {
         thread->sender = NULL;
     }
 
-    thread->exit_status = status;
+    thread->exit_value = exit_value;
 
     /* When we started the thread in start_thread(), we incremented the
      * reference count on it to ensure it continues running even if all

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -35,15 +35,13 @@
 #include <kernel/domain/services/ipc.h>
 #include <kernel/machine/thread.h>
 
-void exit_thread(void *exit_value) {
+void exit_thread(void) {
     thread_t *thread = get_current_thread();
 
     if(thread->sender != NULL) {
         abort_message(thread->sender);
         thread->sender = NULL;
     }
-
-    thread->exit_value = exit_value;
 
     if(thread->joined != NULL) {
         ready_thread(thread->joined);

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -29,9 +29,26 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <jinue/shared/asm/errno.h>
 #include <kernel/application/syscalls.h>
 #include <kernel/domain/entities/thread.h>
+#include <kernel/domain/services/ipc.h>
+#include <kernel/machine/thread.h>
 
 void exit_thread(void) {
-    exit_current_thread();
+    thread_t *thread = get_current_thread();
+
+    if(thread->sender != NULL) {
+        abort_message(thread->sender, JINUE_EIO);
+    }
+
+    /* When we started the thread in start_thread(), we incremented the
+     * reference count on it to ensure it continues running even if all
+     * descriptors that reference it are closed. This call here will safely
+     * decrement the reference count after it has switched to another thread.
+     * We cannot just decrement the count here because that will possibly free
+     * the current thread, which we don't want to do while it is still running.
+     * 
+     * This call must be the last thing happening in this function. */
+    switch_from_exiting_thread(thread);
 }

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -39,7 +39,8 @@ void exit_thread(int status) {
     thread_t *thread = get_current_thread();
 
     if(thread->sender != NULL) {
-        abort_message(thread->sender, JINUE_EIO);
+        abort_message(thread->sender);
+        thread->sender = NULL;
     }
 
     thread->exit_status = status;

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -35,12 +35,14 @@
 #include <kernel/domain/services/ipc.h>
 #include <kernel/machine/thread.h>
 
-void exit_thread(void) {
+void exit_thread(int status) {
     thread_t *thread = get_current_thread();
 
     if(thread->sender != NULL) {
         abort_message(thread->sender, JINUE_EIO);
     }
+
+    thread->exit_status = status;
 
     /* When we started the thread in start_thread(), we incremented the
      * reference count on it to ensure it continues running even if all

--- a/kernel/application/syscalls/join_thread.c
+++ b/kernel/application/syscalls/join_thread.c
@@ -37,7 +37,7 @@
 #include <kernel/domain/entities/thread.h>
 #include <kernel/machine/thread.h>
 
-int join_thread(int fd, void **exit_value) {
+int join_thread(int fd) {
     descriptor_t *desc;
     int status = dereference_object_descriptor(&desc, get_current_process(), fd);
 
@@ -73,8 +73,6 @@ int join_thread(int fd, void **exit_value) {
     if(thread->state != THREAD_STATE_ZOMBIE) {
         block_current_thread();
     }
-
-    *exit_value = thread->exit_value;
 
     sub_ref_to_object(&thread->header);
 

--- a/kernel/application/syscalls/mclone.c
+++ b/kernel/application/syscalls/mclone.c
@@ -79,7 +79,7 @@ int mclone(int src, int dest, const jinue_mclone_args_t *args) {
         return -JINUE_EBADF;
     }
 
-    if(!descriptor_has_permissions(dest_desc, JINUE_PERM_OPEN)) {
+    if(!descriptor_has_permissions(dest_desc, JINUE_PERM_MAP)) {
         return -JINUE_EPERM;
     }
 

--- a/kernel/application/syscalls/start_thread.c
+++ b/kernel/application/syscalls/start_thread.c
@@ -54,9 +54,11 @@ int start_thread(int fd, const thread_params_t *params) {
         return -JINUE_EPERM;
     }
 
-    prepare_thread(thread, params);
+    if(thread->state != THREAD_STATE_ZOMBIE) {
+        return -JINUE_EBUSY;
+    }
 
-    /* TODO protect against the case where the trhead is already running */
+    prepare_thread(thread, params);
 
     /* Add a reference on the thread while it is running so it is allowed to
      * run to completion even if all descriptors that reference it are

--- a/kernel/application/syscalls/start_thread.c
+++ b/kernel/application/syscalls/start_thread.c
@@ -56,6 +56,13 @@ int start_thread(int fd, const thread_params_t *params) {
 
     prepare_thread(thread, params);
 
+    /* TODO protect against the case where the trhead is already running */
+
+    /* Add a reference on the thread while it is running so it is allowed to
+     * run to completion even if all descriptors that reference it are
+     * closed. */
+    add_ref_to_object(&thread->header);
+
     ready_thread(thread);
 
     return 0;

--- a/kernel/application/syscalls/start_thread.c
+++ b/kernel/application/syscalls/start_thread.c
@@ -5,18 +5,18 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the author nor the names of other contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,49 +29,34 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_APPLICATION_SYSCALLS_H
-#define JINUE_KERNEL_APPLICATION_SYSCALLS_H
+#include <jinue/shared/asm/errno.h>
+#include <kernel/application/syscalls.h>
+#include <kernel/domain/entities/descriptor.h>
+#include <kernel/domain/entities/object.h>
+#include <kernel/domain/entities/process.h>
+#include <kernel/domain/entities/thread.h>
 
-#include <kernel/types.h>
+int start_thread(int fd, const thread_params_t *params) {
+    descriptor_t *desc;
+    int status = dereference_object_descriptor(&desc, get_current_process(), fd);
 
-int close(int fd);
+    if(status < 0) {
+        return -JINUE_EBADF;
+    }
 
-int create_endpoint(int fd);
+    thread_t *thread = get_thread_from_descriptor(desc);
 
-int create_process(int fd);
+    if(thread == NULL) {
+        return -JINUE_EBADF;
+    }
 
-int create_thread(int fd, int process_fd);
+    if(!descriptor_has_permissions(desc, JINUE_PERM_START)) {
+        return -JINUE_EPERM;
+    }
 
-int destroy(int fd);
+    prepare_thread(thread, params);
 
-int dup(int process_fd, int src, int dest);
+    ready_thread(thread);
 
-void exit_thread(void);
-
-void *get_thread_local(void);
-
-int get_user_memory(const jinue_buffer_t *buffer);
-
-int mclone(int src, int dest, const jinue_mclone_args_t *args);
-
-int mint(int owner, const jinue_mint_args_t *mint_args);
-
-int mmap(int process_fd, const jinue_mmap_args_t *args);
-
-int puts(int loglevel, const char *str, size_t length);
-
-void reboot(void);
-
-int receive(int fd, jinue_message_t *message);
-
-int reply(const jinue_message_t *message);
-
-int send(int fd, int function, const jinue_message_t *message);
-
-void set_thread_local(void *addr, size_t size);
-
-int start_thread(int fd, const thread_params_t *params);
-
-void yield_thread(void);
-
-#endif
+    return 0;
+}

--- a/kernel/domain/entities/endpoint.c
+++ b/kernel/domain/entities/endpoint.c
@@ -146,7 +146,7 @@ static void destroy_endpoint(object_header_t *object) {
             break;
         }
 
-        abort_message(sender, JINUE_EIO);
+        abort_message(sender);
     }
 
     while(true) {
@@ -159,7 +159,7 @@ static void destroy_endpoint(object_header_t *object) {
             break;
         }
 
-        abort_message(receiver, JINUE_EIO);
+        abort_message(receiver);
     }
 }
 

--- a/kernel/domain/entities/object.c
+++ b/kernel/domain/entities/object.c
@@ -72,6 +72,7 @@ void destroy_object(object_header_t *object) {
     }
 }
 
+/* This function is called by assembly code. See thread_context_switch_stack(). */
 void sub_ref_to_object(object_header_t *object) {
     --object->ref_count;
 

--- a/kernel/domain/entities/process.c
+++ b/kernel/domain/entities/process.c
@@ -49,8 +49,7 @@ static void free_process(object_header_t *object);
 /** runtime type definition for a process */
 static const object_type_t object_type = {
     .all_permissions    =
-              JINUE_PERM_CLOSE
-            | JINUE_PERM_CREATE_THREAD
+              JINUE_PERM_CREATE_THREAD
             | JINUE_PERM_MAP
             | JINUE_PERM_OPEN,
     .name               = "process",

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -42,7 +42,7 @@ static void free_thread(object_header_t *object);
 
 /** runtime type definition for a thread */
 static const object_type_t object_type = {
-    .all_permissions    = JINUE_PERM_START,
+    .all_permissions    = JINUE_PERM_START | JINUE_PERM_JOIN,
     .name               = "thread",
     .size               = sizeof(thread_t),
     .open               = NULL,
@@ -70,7 +70,11 @@ thread_t *construct_thread(process_t *process) {
 
     thread->state               = THREAD_STATE_ZOMBIE;
     thread->process             = process;
-    thread->sender              = NULL;
+    /* Arbitrary non-NULL value to signify the thread hasn't run yet and
+     * shouldn't be joined. This will fall in the condition in thread_join()
+     * that detects an attempt to join a thread that has already been joined,
+     * so thread_join() will fail with JINUE_ESRCH. */
+    thread->joined              = thread;
     thread->local_storage_addr  = NULL;
     thread->local_storage_size  = 0;
  
@@ -83,7 +87,9 @@ static void free_thread(object_header_t *object) {
 }
 
 void prepare_thread(thread_t *thread, const thread_params_t *params) {
-    thread->exit_value = 0;
+    thread->sender      = NULL;
+    thread->joined      = NULL;
+    thread->exit_value  = 0;
     machine_prepare_thread(thread, params);
 }
 

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -57,7 +57,7 @@ const object_type_t *object_type_thread = &object_type;
 
 static jinue_list_t ready_list = JINUE_LIST_STATIC;
 
-thread_t *construct_thread(process_t *process, const thread_params_t *params) {
+thread_t *construct_thread(process_t *process) {
     thread_t *thread = machine_alloc_thread();
 
     if(thread == NULL) {
@@ -72,17 +72,17 @@ thread_t *construct_thread(process_t *process, const thread_params_t *params) {
     thread->sender              = NULL;
     thread->local_storage_addr  = NULL;
     thread->local_storage_size  = 0;
-
-    machine_init_thread(thread, params);
-
-    ready_thread(thread);
-    
+ 
     return thread;
 }
 
 /* This function is called by assembly code. See thread_context_switch_stack(). */
 void free_thread(thread_t *thread) {
     machine_free_thread(thread);
+}
+
+void prepare_thread(thread_t *thread, const thread_params_t *params) {
+    machine_prepare_thread(thread, params);
 }
 
 void ready_thread(thread_t *thread) {
@@ -142,10 +142,10 @@ void switch_to_thread(thread_t *thread, bool blocked) {
     );
 }
 
-void start_first_thread(void) {
+void start_first_thread(thread_t *thread) {
     switch_thread(
             NULL,
-            reschedule(false),
+            thread,
             false               /* don't destroy current thread */
     );
 }

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Philippe Aubertin.
+ * Copyright (C) 2019-2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -87,9 +87,8 @@ static void free_thread(object_header_t *object) {
 }
 
 void prepare_thread(thread_t *thread, const thread_params_t *params) {
-    thread->sender      = NULL;
-    thread->joined      = NULL;
-    thread->exit_value  = 0;
+    thread->sender = NULL;
+    thread->joined = NULL;
     machine_prepare_thread(thread, params);
 }
 

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -83,7 +83,7 @@ static void free_thread(object_header_t *object) {
 }
 
 void prepare_thread(thread_t *thread, const thread_params_t *params) {
-    thread->exit_status = 0;
+    thread->exit_value = 0;
     machine_prepare_thread(thread, params);
 }
 

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -42,7 +42,7 @@
 
 /** runtime type definition for a thread */
 static const object_type_t object_type = {
-    .all_permissions    = 0,
+    .all_permissions    = JINUE_PERM_START,
     .name               = "thread",
     .size               = sizeof(thread_t),
     .open               = NULL,

--- a/kernel/domain/services/exec.c
+++ b/kernel/domain/services/exec.c
@@ -36,16 +36,12 @@
 
 void exec(
         process_t           *process,
+        thread_t            *thread,
         const exec_file_t   *exec_file,
         const char          *argv0,
         const char          *cmdline) {
     
     thread_params_t thread_params;
     machine_load_exec(&thread_params, process, exec_file, argv0, cmdline);
-
-    thread_t *thread = construct_thread(process, &thread_params);
-    
-    if(thread == NULL) {
-        panic("Thread creation failed.");
-    }
+    prepare_thread(thread, &thread_params);
 }

--- a/kernel/domain/services/ipc.c
+++ b/kernel/domain/services/ipc.c
@@ -387,18 +387,18 @@ int reply_to_message(thread_t *replier, const jinue_message_t *message) {
 /**
  * Abort a send or receive operation in progress
  *
- * This function should only be called on a blocked thread that was just
- * dequeued from an IPC endpoint's send or receive queue. The send or receive
- * operation is aborted and the IPC system call returns specified error number.
- *
- * @param thread blocked thread requeued from send or receive queue
- * @param errno error number
+ * The send or receive operation fails with JINUE_EIO.
+ * 
+ * Situations that make calling this function necessary:
+ *  - The thread is queued on an IPC endpoint's send or receive queue and the
+ *    endpoint is being destroyed.
+ *  - The sending thread is blocked being serviced by a receiver thread and the
+ *    receiver thread exits without replying.
+ * 
+ * @param thread thread blocked on an IPC operation
  *
  */
-void abort_message(thread_t *thread, int errno) {
-    thread->message_errno   = errno;
-    /* TODO fix thread servicing message itself sending a message
-     * (i.e. don't clear sender when aborting as send) */
-    thread->sender          = NULL;
+void abort_message(thread_t *thread) {
+    thread->message_errno = JINUE_EIO;
     ready_thread(thread);
 }

--- a/kernel/infrastructure/i686/thread.c
+++ b/kernel/infrastructure/i686/thread.c
@@ -88,7 +88,7 @@ static addr_t get_kernel_stack_base(machine_thread_t *thread_ctx) {
     return (addr_t)thread + THREAD_CONTEXT_SIZE;
 }
 
-void machine_init_thread(thread_t *thread, const thread_params_t *params) {
+void machine_prepare_thread(thread_t *thread, const thread_params_t *params) {
     /* initialize fields */
     machine_thread_t *thread_ctx = &thread->thread_ctx;
 

--- a/kernel/infrastructure/i686/thread_switch.asm
+++ b/kernel/infrastructure/i686/thread_switch.asm
@@ -32,7 +32,7 @@
 
     bits 32
     
-    extern free_thread
+    extern sub_ref_to_object
 
 ; ------------------------------------------------------------------------------
 ; FUNCTION: thread_context_switch_stack
@@ -88,11 +88,11 @@ thread_context_switch_stack:
     
     ; Restore the saved registers.
     ;
-    ; We do this before calling free_thread(). Otherwise, the frame pointer
-    ; still refers to the thread stack for the previous thread, i.e. the one
-    ; we are potentially about to destroy, when free_thread() is called.
-    ; This is a problem if e.g. we try to dump the call stack from free_thread()
-    ; or one of its callees.
+    ; We do this before calling sub_ref_to_object(). Otherwise, the frame
+    ; pointer still refers to the thread stack for the previous thread, i.e.
+    ; the one we are potentially about to destroy when sub_ref_to_object() is
+    ; called. This is a problem if e.g. we try to dump the call stack from
+    ; sub_ref_to_object() or one of its callees.
     pop edi
     pop esi
     pop ebx
@@ -106,9 +106,9 @@ thread_context_switch_stack:
     ; destroy from thread context
     and ecx, THREAD_CONTEXT_MASK
     push ecx
-    call free_thread
+    call sub_ref_to_object
     
-    ; cleanup free_thread() arguments from stack
+    ; cleanup sub_ref_to_object() arguments from stack
     add esp, 4
 
 .skip_destroy:

--- a/kernel/interface/syscalls.c
+++ b/kernel/interface/syscalls.c
@@ -132,7 +132,9 @@ static void sys_yield_thread(jinue_syscall_args_t *args) {
 }
 
 static void sys_exit_thread(jinue_syscall_args_t *args) {
-    exit_thread();
+    int status = (int)(args->arg1 & 0xff);
+
+    exit_thread(status);
     set_return_value(args, 0);
 }
 

--- a/kernel/interface/syscalls.c
+++ b/kernel/interface/syscalls.c
@@ -80,15 +80,6 @@ static void set_return_value_or_error(jinue_syscall_args_t *args, int retval) {
     }
 }
 
-static void set_return_pointer_or_error(jinue_syscall_args_t *args, int retval, void *ptr) {
-    if(retval < 0) {
-        set_error(args, -retval);
-    }
-    else {
-        set_return_pointer(args, ptr);
-    }
-}
-
 static int get_descriptor(uintptr_t value) {
     /* This handles the obvious case where the original value was positive and
      * too large, but also the case where an originally negative value was cast
@@ -141,10 +132,8 @@ static void sys_yield_thread(jinue_syscall_args_t *args) {
 }
 
 static void sys_exit_thread(jinue_syscall_args_t *args) {
-    void *exit_value = (void *)args->arg1;
-
-    exit_thread(exit_value);
-    set_return_value(args, 0);
+    exit_thread();
+    /* No need to set a return value since exit_thread() does not return. */
 }
 
 static void sys_set_thread_local(jinue_syscall_args_t *args) {
@@ -557,9 +546,8 @@ static void sys_join_thread(jinue_syscall_args_t *args) {
         return;
     }
 
-    void *exit_value;
-    int retval = join_thread(fd, &exit_value);
-    set_return_pointer_or_error(args, retval, exit_value);
+    int retval = join_thread(fd);
+    set_return_value_or_error(args, retval);
 }
 
 /**

--- a/kernel/interface/syscalls.c
+++ b/kernel/interface/syscalls.c
@@ -132,9 +132,9 @@ static void sys_yield_thread(jinue_syscall_args_t *args) {
 }
 
 static void sys_exit_thread(jinue_syscall_args_t *args) {
-    int status = (int)(args->arg1 & 0xff);
+    void *exit_value = (void *)args->arg1;
 
-    exit_thread(status);
+    exit_thread(exit_value);
     set_return_value(args, 0);
 }
 

--- a/userspace/lib/jinue/Makefile
+++ b/userspace/lib/jinue/Makefile
@@ -38,13 +38,13 @@ target.utils        = $(notdir $(libjinue_utils))
 targets             = $(target.syscalls) $(target.utils)
 
 objects.syscalls    = i686/stubs.o i686/syscalls.o syscalls.o
-objects.util        = loader.o logging.o
+objects.utils       = loader.o logging.o threads.o
 
 include $(common)
 
 $(target.syscalls): $(objects.syscalls)
 
-$(target.utils): $(objects.util)
+$(target.utils): $(objects.utils)
 
 %.a:
 	ar rcs $@ $^

--- a/userspace/lib/jinue/i686/stubs.asm
+++ b/userspace/lib/jinue/i686/stubs.asm
@@ -224,7 +224,6 @@ jinue_thread_entry:
     push eax
 
     ; Exit the thread.
-    push 0  ; TODO remove this
     call jinue_exit_thread
 
 .end:

--- a/userspace/lib/jinue/i686/stubs.asm
+++ b/userspace/lib/jinue/i686/stubs.asm
@@ -30,6 +30,8 @@
 #include <jinue/shared/asm/i686.h>
 
     bits 32
+
+    extern jinue_exit_thread
     
     section .text
 ; ------------------------------------------------------------------------------
@@ -197,5 +199,32 @@ jinue_syscall_intr:
     pop ebx
 
     ret
+
+.end:
+
+; ------------------------------------------------------------------------------
+; FUNCTION: jinue_thread_entry
+; C PROTOTYPE: void jinue_thread_entry(void);
+; ------------------------------------------------------------------------------
+    global jinue_thread_entry:function (jinue_thread_entry.end - jinue_thread_entry)
+jinue_thread_entry:
+    ; Set up the frame pointer
+    mov ebp, esp
+
+    ; Pop address of the thread function from the stack. Leave the argument on
+    ; the stack since this is where the thread function will expect to find it.
+    pop eax
+
+    ; Call the thread function.
+    call eax
+
+    ; Remove the argument from the stack now that it is no longer needed and
+    ; replace it with the return value of the thread function.
+    pop ebx
+    push eax
+
+    ; Exit the thread.
+    push 0  ; TODO remove this
+    call jinue_exit_thread
 
 .end:

--- a/userspace/lib/jinue/i686/syscalls.c
+++ b/userspace/lib/jinue/i686/syscalls.c
@@ -30,7 +30,6 @@
  */
 
 #include <jinue/jinue.h>
-#include "../machine.h"
 #include "stubs.h"
 
 static jinue_syscall_stub_t syscall_stubs[] = {
@@ -53,20 +52,4 @@ int jinue_init(int implementation, int *perrno) {
 
 uintptr_t jinue_syscall(jinue_syscall_args_t *args) {
     return syscall_stubs[syscall_stub_index](args);
-}
-
-static inline void jinue_set_errno(int *perrno, int errval) {
-    if(perrno != NULL) {
-        *perrno = errval;
-    }
-}
-
-intptr_t jinue_syscall_with_usual_convention(jinue_syscall_args_t *args, int *perrno) {
-    const intptr_t retval = (intptr_t)jinue_syscall(args);
-
-    if(retval < 0) {
-        jinue_set_errno(perrno, args->arg1);
-    }
-
-    return retval;
 }

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -88,11 +88,11 @@ void jinue_yield_thread(void) {
     jinue_syscall(&args);
 }
 
-void jinue_exit_thread(int status) {
+void jinue_exit_thread(void *value_ptr) {
     jinue_syscall_args_t args;
 
     args.arg0 = JINUE_SYS_EXIT_THREAD;
-    args.arg1 = status;
+    args.arg1 = (uintptr_t)value_ptr;
     args.arg2 = 0;
     args.arg3 = 0;
 

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -66,13 +66,13 @@ void *jinue_get_thread_local(void) {
     return (void *)jinue_syscall(&args);
 }
 
-int jinue_create_thread(int process, void (*entry)(void), void *stack, int *perrno) {
+int jinue_create_thread(int fd, int process, int *perrno) {
     jinue_syscall_args_t args;
 
     args.arg0 = JINUE_SYS_CREATE_THREAD;
-    args.arg1 = process;
-    args.arg2 = (uintptr_t)entry;
-    args.arg3 = (uintptr_t)stack;
+    args.arg1 = fd;
+    args.arg2 = process;
+    args.arg3 = 0;
 
     return jinue_syscall_with_usual_convention(&args, perrno);
 }
@@ -283,6 +283,17 @@ int jinue_mint(
     args.arg1 = owner;
     args.arg2 = (uintptr_t)&mint_args;
     args.arg3 = 0;
+
+    return jinue_syscall_with_usual_convention(&args, perrno);
+}
+
+int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno) {
+    jinue_syscall_args_t args;
+
+    args.arg0 = JINUE_SYS_START_THREAD;
+    args.arg1 = fd;
+    args.arg2 = (uintptr_t)entry;
+    args.arg3 = (uintptr_t)stack;
 
     return jinue_syscall_with_usual_convention(&args, perrno);
 }

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -116,11 +116,11 @@ void jinue_yield_thread(void) {
     jinue_syscall(&args);
 }
 
-void jinue_exit_thread(void *value_ptr) {
+void jinue_exit_thread(void) {
     jinue_syscall_args_t args;
 
     args.arg0 = JINUE_SYS_EXIT_THREAD;
-    args.arg1 = (uintptr_t)value_ptr;
+    args.arg1 = 0;
     args.arg2 = 0;
     args.arg3 = 0;
 
@@ -326,7 +326,7 @@ int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno) {
     return call_with_usual_convention(&args, perrno);
 }
 
-int jinue_join_thread(int fd, void **exit_value, int *perrno) {
+int jinue_join_thread(int fd, int *perrno) {
     jinue_syscall_args_t args;
 
     args.arg0 = JINUE_SYS_JOIN_THREAD;
@@ -334,5 +334,5 @@ int jinue_join_thread(int fd, void **exit_value, int *perrno) {
     args.arg2 = 0;
     args.arg3 = 0;
 
-    return call_with_pointer_convention(&args, exit_value, NULL);
+    return call_with_usual_convention(&args, perrno);
 }

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Philippe Aubertin.
+ * Copyright (C) 2019-2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -88,11 +88,11 @@ void jinue_yield_thread(void) {
     jinue_syscall(&args);
 }
 
-void jinue_exit_thread(void) {
+void jinue_exit_thread(int status) {
     jinue_syscall_args_t args;
 
     args.arg0 = JINUE_SYS_EXIT_THREAD;
-    args.arg1 = 0;
+    args.arg1 = status;
     args.arg2 = 0;
     args.arg3 = 0;
 

--- a/userspace/lib/jinue/threads.c
+++ b/userspace/lib/jinue/threads.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Philippe Aubertin.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the author nor the names of other contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <jinue/jinue.h>
+#include <jinue/threads.h>
+#include <sys/mman.h>
+#include <errno.h>
+
+struct jinue_thread {
+    /* The first two members must be in this order and at the start of the
+     * structure, i.e. they must be at the top of the stack when the thread
+     * starts. jinue_thread_entry() relies on this. */
+    void    *(*start_routine)(void*);
+    void    *arg_and_retval;
+    int      fd;
+};
+
+int jinue_thread_init(jinue_thread_t *thread, int fd, size_t stacksize) {
+    int status = jinue_create_thread(fd, JINUE_DESC_SELF_PROCESS, &errno);
+
+    if(status < 0) {
+        return status;
+    }
+
+    char *stack = mmap(
+            NULL,
+            stacksize,
+            JINUE_PROT_READ | JINUE_PROT_WRITE,
+            MAP_SHARED | MAP_ANONYMOUS,
+            -1,
+            0
+    );
+
+    if(stack == MAP_FAILED) {
+        jinue_close(fd, NULL);
+        return -1;
+    }
+
+    char *stackbase = stack + stacksize;
+    *thread = (struct jinue_thread *)stackbase - 1;
+
+    (*thread)->fd = fd;
+
+    return 0;
+}
+
+int jinue_thread_start(jinue_thread_t thread, void *(*start_routine)(void*), void *arg) {
+    thread->start_routine   = start_routine;
+    thread->arg_and_retval  = arg;
+    return jinue_start_thread(thread->fd, jinue_thread_entry, &thread->start_routine, &errno);
+}
+
+int jinue_thread_join(jinue_thread_t thread, void **value_ptr) {
+    void *discarded;
+    int status = jinue_join_thread(thread->fd, &discarded, &errno);
+
+    if(status < 0) {
+        return status;
+    }
+
+    *value_ptr = thread->arg_and_retval;
+
+    return 0;
+}
+
+int jinue_thread_destroy(jinue_thread_t thread) {
+    /* TODO dealloc/unmap stack */
+    return jinue_close(thread->fd, &errno);
+}

--- a/userspace/lib/jinue/threads.c
+++ b/userspace/lib/jinue/threads.c
@@ -79,8 +79,7 @@ int jinue_thread_start(jinue_thread_t thread, void *(*start_routine)(void*), voi
 }
 
 int jinue_thread_join(jinue_thread_t thread, void **value_ptr) {
-    void *discarded;
-    int status = jinue_join_thread(thread->fd, &discarded, &errno);
+    int status = jinue_join_thread(thread->fd, &errno);
 
     if(status < 0) {
         return status;

--- a/userspace/lib/libc/crt.asm
+++ b/userspace/lib/libc/crt.asm
@@ -91,9 +91,6 @@ _start:
     
     ; Exit the thread
 .exit:
-    ; Set main() or _init() exit status as the single argument to
-    ; jinue_exit_thread()
-    push eax
     call jinue_exit_thread
 
 .end:

--- a/userspace/lib/libc/crt.asm
+++ b/userspace/lib/libc/crt.asm
@@ -83,6 +83,7 @@ _start:
     
     call _init
 
+    ; Check _init() exit status, skip main() if non-zero 
     or eax, eax
     jnz .exit
 
@@ -90,6 +91,9 @@ _start:
     
     ; Exit the thread
 .exit:
+    ; Set main() or _init() exit status as the single argument to
+    ; jinue_exit_thread()
+    push eax
     call jinue_exit_thread
 
 .end:

--- a/userspace/lib/libc/string.c
+++ b/userspace/lib/libc/string.c
@@ -137,8 +137,10 @@ static const char *strerror_const(int errnum) {
         return "no message of the desired type";
     case ENOTSUP:
         return "not supported";
+    case EBUSY:
+        return "device or resource busy";
     default:
-        return "Unknown error";
+        return "unknown error";
     }
 }
 

--- a/userspace/lib/libc/string.c
+++ b/userspace/lib/libc/string.c
@@ -139,6 +139,10 @@ static const char *strerror_const(int errnum) {
         return "not supported";
     case EBUSY:
         return "device or resource busy";
+    case ESRCH:
+        return "no such process";
+    case EDEADLK:
+        return "resource deadlock would occur";
     default:
         return "unknown error";
     }

--- a/userspace/loader/loader.c
+++ b/userspace/loader/loader.c
@@ -173,7 +173,12 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    /* TODO close thread descriptor */
+    status = jinue_close(INIT_THREAD_DESCRIPTOR, &errno);
+
+    if (status != 0) {
+        jinue_error("error: could not close thread descriptor: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/userspace/loader/loader.c
+++ b/userspace/loader/loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Philippe Aubertin.
+ * Copyright (C) 2023-2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/testapp/testapp.c
+++ b/userspace/testapp/testapp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Philippe Aubertin.
+ * Copyright (C) 2019-2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -46,6 +46,7 @@
 
 #define CLIENT_THREAD_DESCRIPTOR    2
 
+static int client_thread_retval = 42;
 
 static char ipc_test_thread_stack[THREAD_STACK_SIZE];
 
@@ -122,7 +123,7 @@ static void ipc_test_client_thread(void) {
 
     jinue_info("Client thread is exiting.");
 
-    jinue_exit_thread(42);
+    jinue_exit_thread(&client_thread_retval);
 }
 
 void run_ipc_test(void) {

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -122,7 +122,7 @@ static void ipc_test_client_thread(void) {
 
     jinue_info("Client thread is exiting.");
 
-    jinue_exit_thread();
+    jinue_exit_thread(42);
 }
 
 void run_ipc_test(void) {

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -198,6 +198,8 @@ void run_ipc_test(void) {
         return;
     }
 
+    jinue_info("Closing client thread descriptor.");
+
     status = jinue_close(CLIENT_THREAD_DESCRIPTOR, &errno);
 
     if(status < 0) {

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -198,6 +198,12 @@ void run_ipc_test(void) {
         return;
     }
 
+    status = jinue_close(CLIENT_THREAD_DESCRIPTOR, &errno);
+
+    if(status < 0) {
+        jinue_error("error: failed to close client thread descriptor: %s", strerror(errno));
+        return;
+    }
 
     ret = jinue_receive(ENDPOINT_DESCRIPTOR, &message, &errno);
 
@@ -242,15 +248,13 @@ void run_ipc_test(void) {
     status = jinue_close(ENDPOINT_DESCRIPTOR, &errno);
 
     if(status < 0) {
-        jinue_error("error: jinue_close() failed: %s", strerror(errno));
+        jinue_error("error: failed to close endpoint descriptor: %s", strerror(errno));
         return;
     }
 
     /* Give a chance to the client thread to notice that its second call to
      * jinue_send() failed. */
     jinue_yield_thread();
-
-    /* TODO close thread descriptor */
 
     jinue_info("Main thread is running.");
 }


### PR DESCRIPTION
* Have the `CREATE_THREAD` system call bind the thread it creates to a descriptor.
* Decouple starting a thread (`START_THREAD`) from creating a thread (`CREATE_THREAD`). This way, a process can be given the permissions needed to manage a thread pool but not to create threads itself, to allow a system service to control resource usage.
* Add `JOIN_THREAD` system call.