### PR TITLE
REPLY_ERROR system call

### DIFF
--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -28,7 +28,8 @@
 | 19      | [MINT](mint.md)                         | Mint a Descriptor                    |
 | 20      | [START_THREAD](start-thread.md)         | Start a Thread                       |
 | 21      | [JOIN_THREAD](join-thread.md)           | Wait for a Thread to Exit            |
-| 22-4095 | -                                       | Reserved                             |
+| 22      | [REPLY_ERROR](reply-error.md)           | Reply to Message with an Error       !
+| 23-4095 | -                                       | Reserved                             |
 | 4096+   | [SEND](send.md)                         | Send Message                         |
 
 #### Reserved Function Numbers

--- a/doc/syscalls/reply-error.md
+++ b/doc/syscalls/reply-error.md
@@ -1,0 +1,56 @@
+# REPLY_ERROR - Reply to Message with an Error
+
+## Description
+
+Reply to the current message with an error code. This function should be
+called after calling the [RECEIVE](receive.md) system call in order to send
+an error reply and complete processing of the message.
+
+When this function is called, the call to [send](send.md) that caused the
+current message to be received fails with error number
+[JINUE_EPROTO](../../include/jinue/shared/asm/errno.h) and the error code
+specified to this function is part of the return value. See [send](send.md)
+for detail.
+
+## Arguments
+
+Function number (`arg0`) is 22.
+
+The error code is set in `arg1`
+
+```
+    +----------------------------------------------------------------+
+    |                        function = 22                           |  arg0
+    +----------------------------------------------------------------+
+    31                                                               0
+    
+    +----------------------------------------------------------------+
+    |                          error code                            |  arg1
+    +----------------------------------------------------------------+
+    31                                                               0
+
+    +----------------------------------------------------------------+
+    |                         reserved (0)                           |  arg2
+    +----------------------------------------------------------------+
+    31                                                               0
+
+    +----------------------------------------------------------------+
+    |                         reserved (0)                           |  arg3
+    +----------------------------------------------------------------+
+    31                                                               0
+```
+
+## Return Value
+
+On success, this function returns 0 (in `arg0`). On failure, it returns -1 and
+an error number is set (in `arg1`).
+
+## Errors
+
+* JINUE_ENOMSG if there is no current message, which means either:
+    * [RECEIVE](receive.md) was not called; or
+    * [RECEIVE](receive.md) was called but did not return successfully; or
+    * This function or [REPLY](reply.md) was already called at least once since
+      the last call to [RECEIVE](receive.md).
+* JINUE_EINVAL if the error code cannot be represented as a C `int` type or is
+less or equal to zero.

--- a/doc/syscalls/reply-error.md
+++ b/doc/syscalls/reply-error.md
@@ -6,10 +6,10 @@ Reply to the current message with an error code. This function should be
 called after calling the [RECEIVE](receive.md) system call in order to send
 an error reply and complete processing of the message.
 
-When this function is called, the call to [send](send.md) that caused the
+When this function is called, the call to [SEND](send.md) that caused the
 current message to be received fails with error number
 [JINUE_EPROTO](../../include/jinue/shared/asm/errno.h) and the error code
-specified to this function is part of the return value. See [send](send.md)
+specified to this function is part of the return value. See [SEND](send.md)
 for detail.
 
 ## Arguments

--- a/doc/syscalls/reply-error.md
+++ b/doc/syscalls/reply-error.md
@@ -52,5 +52,3 @@ an error number is set (in `arg1`).
     * [RECEIVE](receive.md) was called but did not return successfully; or
     * This function or [REPLY](reply.md) was already called at least once since
       the last call to [RECEIVE](receive.md).
-* JINUE_EINVAL if the error code cannot be represented as a C `int` type or is
-less or equal to zero.

--- a/doc/syscalls/reply.md
+++ b/doc/syscalls/reply.md
@@ -46,8 +46,8 @@ an error number is set (in `arg1`).
 * JINUE_ENOMSG if there is no current message, which means either:
     * [RECEIVE](receive.md) was not called; or
     * [RECEIVE](receive.md) was called but did not return successfully; or
-    * This function was already called at least once since the last call to
-      [RECEIVE](receive.md).
+    * This function or [REPLY_ERROR](reply-error.md) was already called at
+      least once since the last call to [RECEIVE](receive.md).
 * JINUE_E2BIG if the reply message is too big for the sender's receive buffer
 size.
 * JINUE_EINVAL in any of the following situations:

--- a/doc/syscalls/send.md
+++ b/doc/syscalls/send.md
@@ -47,9 +47,9 @@ reply.
 On success, this function returns the size of the reply in bytes (in `arg0`).
 On failure, it returns -1 and an error number is set (in `arg1`).
 
-If the function fails with error number
+If this function fails with error number
 [JINUE_EPROTO](../../include/jinue/shared/asm/errno.h), it means the receiving
-thread replied with an error number by calling [REPLY_ERROR](reply-error.md).
+thread replied with an error code by calling [REPLY_ERROR](reply-error.md).
 In that case, the error code specified to [REPLY_ERROR](reply-error.md) is set
 in `arg2`.
     

--- a/doc/syscalls/send.md
+++ b/doc/syscalls/send.md
@@ -44,9 +44,14 @@ reply.
 
 ## Return Value
 
-On success, the return value set in `arg0` is the size of the reply in bytes. On
-failure, the return value set in `arg0` is -1 and an error number is set in
-`arg1`.
+On success, this function returns the size of the reply in bytes (in `arg0`).
+On failure, it returns -1 and an error number is set (in `arg1`).
+
+If the function fails with error number
+[JINUE_EPROTO](../../include/jinue/shared/asm/errno.h), it means the receiving
+thread replied with an error number by calling [REPLY_ERROR](reply-error.md).
+In that case, the error code specified to [REPLY_ERROR](reply-error.md) is set
+in `arg2`.
     
 ## Errors
 
@@ -62,6 +67,8 @@ too large for its receive buffer(s).
     * If any part of any of the send and/or receive buffers belongs to the kernel.
     * If the send and/or receive buffers array have more than 256 elements.
     * If any of the receive buffers is larger than 64 MB.
+* JINUE_EPROTO the receiving thread failed the exchange by calling
+[REPLY_ERROR](reply-error.md).
 
 ## Future Direction
 

--- a/include/errno.h
+++ b/include/errno.h
@@ -62,4 +62,6 @@ extern int errno;
 
 #define EDEADLK     JINUE_EDEADLK
 
+#define EPROTO      JINUE_EPROTO
+
 #endif

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -80,7 +80,8 @@ intptr_t jinue_send(
         int                      fd,
         intptr_t                 function,
         const jinue_message_t   *message,
-        int                     *perrno);
+        int                     *perrno,
+        uintptr_t               *perrcode);
 
 intptr_t jinue_receive(int fd, const jinue_message_t *message, int *perrno);
 
@@ -116,5 +117,7 @@ int jinue_mint(
 int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno);
 
 int jinue_join_thread(int fd, int *perrno);
+
+int jinue_reply_error(uintptr_t errcode, int *perrno);
 
 #endif

--- a/include/jinue/shared/asm/errno.h
+++ b/include/jinue/shared/asm/errno.h
@@ -71,4 +71,7 @@
 /** resource deadlock would occur */
 #define JINUE_EDEADLK   13
 
+/** protocol error */
+#define JINUE_EPROTO    14
+
 #endif

--- a/include/jinue/shared/asm/syscalls.h
+++ b/include/jinue/shared/asm/syscalls.h
@@ -92,6 +92,9 @@
 /** wait for a thread to exit */
 #define JINUE_SYS_JOIN_THREAD           21
 
+/** reply to current message with an error code */
+#define JINUE_SYS_REPLY_ERROR           22
+
 /** start of function numbers for user space messages */
 #define JINUE_SYS_USER_BASE             4096
 

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -68,7 +68,9 @@ int receive(int fd, jinue_message_t *message);
 
 int reply(const jinue_message_t *message);
 
-int send(int fd, int function, const jinue_message_t *message);
+int reply_error(uintptr_t errcode);
+
+int send(uintptr_t *errcode, int fd, int function, const jinue_message_t *message);
 
 void set_thread_local(void *addr, size_t size);
 

--- a/include/kernel/domain/services/ipc.h
+++ b/include/kernel/domain/services/ipc.h
@@ -35,6 +35,7 @@
 #include <kernel/types.h>
 
 int send_message(
+        uintptr_t               *errcode,
         ipc_endpoint_t          *endpoint,
         thread_t                *sender,
         int                      function,
@@ -44,6 +45,8 @@ int send_message(
 int receive_message(ipc_endpoint_t *endpoint, thread_t *receiver,jinue_message_t *message);
 
 int reply_to_message(thread_t *replier, const jinue_message_t *message);
+
+int reply_error_to_message(thread_t *replier, uintptr_t errcode);
 
 void abort_message(thread_t *thread);
 

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -114,6 +114,7 @@ struct thread_t {
     size_t                   local_storage_size;
     size_t                   recv_buffer_size;
     int                      message_errno;
+    uintptr_t                message_reply_errcode;
     uintptr_t                message_function;
     uintptr_t                message_cookie;
     size_t                   message_size;

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -77,6 +77,7 @@ sources.kernel.c = \
 	application/syscalls/reboot.c \
 	application/syscalls/receive.c \
 	application/syscalls/reply.c \
+	application/syscalls/reply_error.c \
 	application/syscalls/send.c \
 	application/syscalls/set_thread_local.c \
 	application/syscalls/start_thread.c \

--- a/kernel/application/syscalls/reply.c
+++ b/kernel/application/syscalls/reply.c
@@ -29,8 +29,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <jinue/shared/asm/errno.h>
-#include <jinue/shared/asm/permissions.h>
 #include <kernel/application/syscalls.h>
 #include <kernel/domain/services/ipc.h>
 #include <kernel/machine/thread.h>

--- a/kernel/application/syscalls/reply_error.c
+++ b/kernel/application/syscalls/reply_error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2024 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -29,32 +29,12 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <jinue/shared/asm/errno.h>
-#include <jinue/shared/asm/permissions.h>
 #include <kernel/application/syscalls.h>
-#include <kernel/domain/entities/descriptor.h>
 #include <kernel/domain/services/ipc.h>
 #include <kernel/machine/thread.h>
+#include <stdint.h>
 
-int send(uintptr_t *errcode, int fd, int function, const jinue_message_t *message) {
-    thread_t *sender = get_current_thread();
-
-    descriptor_t *desc;
-    int status = dereference_object_descriptor(&desc, sender->process, fd);
-
-    if(status < 0) {
-        return status;
-    }
-
-    ipc_endpoint_t *endpoint = get_endpoint_from_descriptor(desc);
-
-    if(endpoint == NULL) {
-        return -JINUE_EBADF;
-    }
-
-    if(!descriptor_has_permissions(desc, JINUE_PERM_SEND)) {
-        return -JINUE_EPERM;
-    }
-
-    return send_message(errcode, endpoint, sender, function, desc->cookie, message);
+int reply_error(uintptr_t errcode) {
+    thread_t *replier = get_current_thread();
+    return reply_error_to_message(replier, errcode);
 }

--- a/userspace/lib/libc/string.c
+++ b/userspace/lib/libc/string.c
@@ -145,6 +145,8 @@ static const char *strerror_const(int errnum) {
         return "no such process";
     case EDEADLK:
         return "resource deadlock would occur";
+    case EPROTO:
+        return "protocol errors";
     default:
         return "unknown error";
     }

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -82,7 +82,7 @@ static void ipc_test_run_client(void) {
     message.recv_buffers        = reply_buffers;
     message.recv_buffers_length = 3;
 
-    intptr_t ret = jinue_send(CLIENT_ENDPOINT_DESCRIPTOR, MSG_FUNC_TEST, &message, &errno);
+    intptr_t ret = jinue_send(CLIENT_ENDPOINT_DESCRIPTOR, MSG_FUNC_TEST, &message, &errno, NULL);
 
     if(ret < 0) {
         jinue_error("error: jinue_send() failed: %s.", strerror(errno));
@@ -98,7 +98,7 @@ static void ipc_test_run_client(void) {
     message.recv_buffers        = NULL;
     message.recv_buffers_length = 0;
 
-    ret = jinue_send(CLIENT_ENDPOINT_DESCRIPTOR, MSG_FUNC_TEST, &message, &errno);
+    ret = jinue_send(CLIENT_ENDPOINT_DESCRIPTOR, MSG_FUNC_TEST, &message, &errno, NULL);
 
     if(ret >= 0) {
         jinue_error("error: jinue_send() unexpectedly succeeded");


### PR DESCRIPTION
Create the `REPLY_ERROR` system call that allows a receiving thread processing a message to reply to the message with an error code.