### PR TITLE
Relocatable extracted RAM disk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
     "cmake.configureOnOpen": false,
     "makefile.configureOnOpen": false,
     "files.associations": {
-        "*.h": "c"
+        "*.h": "c",
+        "typeinfo": "c"
     },
     "C_Cpp.default.intelliSenseMode": "linux-gcc-x86"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,7 @@
     "cmake.configureOnOpen": false,
     "makefile.configureOnOpen": false,
     "files.associations": {
-        "*.h": "c",
-        "typeinfo": "c"
+        "*.h": "c"
     },
     "C_Cpp.default.intelliSenseMode": "linux-gcc-x86"
 }

--- a/include/jinue/loader.h
+++ b/include/jinue/loader.h
@@ -33,6 +33,7 @@
 #define _JINUE_LOADER_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 /** normal file */
 #define JINUE_DIRENT_TYPE_FILE      1
@@ -82,17 +83,17 @@
 #define JINUE_IXOTH             (1<<0)
 
 struct jinue_dirent {
-    int                  type;
-    int                  mode;
-    int                  uid;
-    int                  gid;
-    int                  devmajor;
-    int                  devminor;
-    size_t               size;
-    const void          *file;
-    const char          *name;
-    const char          *link;
-    struct jinue_dirent *next;
+    int         type;
+    int         mode;
+    int         uid;
+    int         gid;
+    int         devmajor;
+    int         devminor;
+    size_t      size;
+    const void *file;
+    const char *name;
+    const char *link;
+    int64_t     next;
 };
 
 typedef struct jinue_dirent jinue_dirent_t;

--- a/include/jinue/loader.h
+++ b/include/jinue/loader.h
@@ -90,10 +90,8 @@ struct jinue_dirent {
     uint32_t    devmajor;
     uint32_t    devminor;
     uint64_t    size;
-    int64_t     file;
-    int64_t     name;
-    int64_t     link;
-    int64_t     next;
+    int64_t     rel_name;
+    int64_t     rel_value;
 };
 
 typedef struct jinue_dirent jinue_dirent_t;
@@ -104,9 +102,9 @@ const jinue_dirent_t *jinue_dirent_get_next(const jinue_dirent_t *prev);
 
 const jinue_dirent_t *jinue_dirent_find_by_name(const jinue_dirent_t *root, const char *name);
 
-const void *jinue_dirent_file(const jinue_dirent_t *dirent);
-
 const char *jinue_dirent_name(const jinue_dirent_t *dirent);
+
+const void *jinue_dirent_file(const jinue_dirent_t *dirent);
 
 const char *jinue_dirent_link(const jinue_dirent_t *dirent);
 

--- a/include/jinue/loader.h
+++ b/include/jinue/loader.h
@@ -83,13 +83,13 @@
 #define JINUE_IXOTH             (1<<0)
 
 struct jinue_dirent {
-    int         type;
-    int         mode;
-    int         uid;
-    int         gid;
-    int         devmajor;
-    int         devminor;
-    size_t      size;
+    uint32_t    type;
+    uint32_t    mode;
+    uint32_t    uid;
+    uint32_t    gid;
+    uint32_t    devmajor;
+    uint32_t    devminor;
+    uint64_t    size;
     const void *file;
     const char *name;
     const char *link;

--- a/include/jinue/loader.h
+++ b/include/jinue/loader.h
@@ -90,9 +90,9 @@ struct jinue_dirent {
     uint32_t    devmajor;
     uint32_t    devminor;
     uint64_t    size;
-    const void *file;
-    const char *name;
-    const char *link;
+    int64_t     file;
+    int64_t     name;
+    int64_t     link;
     int64_t     next;
 };
 

--- a/include/jinue/loader.h
+++ b/include/jinue/loader.h
@@ -103,4 +103,10 @@ const jinue_dirent_t *jinue_dirent_get_next(const jinue_dirent_t *prev);
 
 const jinue_dirent_t *jinue_dirent_find_by_name(const jinue_dirent_t *root, const char *name);
 
+const void *jinue_dirent_file(const jinue_dirent_t *dirent);
+
+const char *jinue_dirent_name(const jinue_dirent_t *dirent);
+
+const char *jinue_dirent_link(const jinue_dirent_t *dirent);
+
 #endif

--- a/userspace/lib/jinue/loader.c
+++ b/userspace/lib/jinue/loader.c
@@ -74,13 +74,13 @@ const jinue_dirent_t *jinue_dirent_find_by_name(const jinue_dirent_t *root, cons
 }
 
 const void *jinue_dirent_file(const jinue_dirent_t *dirent) {
-    return dirent->file;
+    return (const char *)dirent + dirent->file;
 }
 
 const char *jinue_dirent_name(const jinue_dirent_t *dirent) {
-    return dirent->name;
+    return (const char *)dirent + dirent->name;
 }
 
 const char *jinue_dirent_link(const jinue_dirent_t *dirent) {
-    return dirent->link;
+    return (const char *)dirent + dirent->link;
 }

--- a/userspace/lib/jinue/loader.c
+++ b/userspace/lib/jinue/loader.c
@@ -63,7 +63,7 @@ const jinue_dirent_t *jinue_dirent_find_by_name(const jinue_dirent_t *root, cons
     const jinue_dirent_t *dirent = jinue_dirent_get_first(root);
 
     while(dirent != NULL) {
-        if(strcmp(dirent->name, name) == 0) {
+        if(strcmp(jinue_dirent_name(dirent), name) == 0) {
             return dirent;
         }
 
@@ -71,4 +71,16 @@ const jinue_dirent_t *jinue_dirent_find_by_name(const jinue_dirent_t *root, cons
     }
 
     return NULL;
+}
+
+const void *jinue_dirent_file(const jinue_dirent_t *dirent) {
+    return dirent->file;
+}
+
+const char *jinue_dirent_name(const jinue_dirent_t *dirent) {
+    return dirent->name;
+}
+
+const char *jinue_dirent_link(const jinue_dirent_t *dirent) {
+    return dirent->link;
 }

--- a/userspace/lib/jinue/loader.c
+++ b/userspace/lib/jinue/loader.c
@@ -49,7 +49,7 @@ const jinue_dirent_t *jinue_dirent_get_next(const jinue_dirent_t *prev) {
     const jinue_dirent_t *current = prev + 1;
 
     if(current->type == JINUE_DIRENT_TYPE_NEXT) {
-        current = current->next;
+        current = (const jinue_dirent_t *)((const char *)current + current->next);
     }
 
     if(current->type == JINUE_DIRENT_TYPE_END) {

--- a/userspace/lib/jinue/loader.c
+++ b/userspace/lib/jinue/loader.c
@@ -49,7 +49,7 @@ const jinue_dirent_t *jinue_dirent_get_next(const jinue_dirent_t *prev) {
     const jinue_dirent_t *current = prev + 1;
 
     if(current->type == JINUE_DIRENT_TYPE_NEXT) {
-        current = (const jinue_dirent_t *)((const char *)current + current->next);
+        current = (const jinue_dirent_t *)((const char *)current + current->rel_value);
     }
 
     if(current->type == JINUE_DIRENT_TYPE_END) {
@@ -73,14 +73,14 @@ const jinue_dirent_t *jinue_dirent_find_by_name(const jinue_dirent_t *root, cons
     return NULL;
 }
 
-const void *jinue_dirent_file(const jinue_dirent_t *dirent) {
-    return (const char *)dirent + dirent->file;
+const char *jinue_dirent_name(const jinue_dirent_t *dirent) {
+    return (const char *)dirent + dirent->rel_name;
 }
 
-const char *jinue_dirent_name(const jinue_dirent_t *dirent) {
-    return (const char *)dirent + dirent->name;
+const void *jinue_dirent_file(const jinue_dirent_t *dirent) {
+    return (const char *)dirent + dirent->rel_value;
 }
 
 const char *jinue_dirent_link(const jinue_dirent_t *dirent) {
-    return (const char *)dirent + dirent->link;
+    return (const char *)dirent + dirent->rel_value;
 }

--- a/userspace/loader/archives/alloc.c
+++ b/userspace/loader/archives/alloc.c
@@ -287,8 +287,8 @@ jinue_dirent_t *append_dirent_to_list(alloc_area_t *area, int type) {
         return NULL;
     }
 
-    link->type = JINUE_DIRENT_TYPE_NEXT;
-    link->next = (char *)area->addr - (char *)link;
+    link->type      = JINUE_DIRENT_TYPE_NEXT;
+    link->rel_value = (char *)area->addr - (char *)link;
 
     return allocate_dirent(area, type);
 }

--- a/userspace/loader/archives/alloc.c
+++ b/userspace/loader/archives/alloc.c
@@ -288,7 +288,7 @@ jinue_dirent_t *append_dirent_to_list(alloc_area_t *area, int type) {
     }
 
     link->type = JINUE_DIRENT_TYPE_NEXT;
-    link->next = area->addr;
+    link->next = (char *)area->addr - (char *)link;
 
     return allocate_dirent(area, type);
 }

--- a/userspace/loader/archives/tar.c
+++ b/userspace/loader/archives/tar.c
@@ -570,16 +570,16 @@ static char *copy_fixed_string(state_t *state, const char *str, size_t size) {
  *
  * */
 static int copy_file_data(state_t *state, jinue_dirent_t *dirent) {
-    dirent->file = allocate_page_aligned(dirent->size);
+    void *dest = allocate_page_aligned(dirent->size);
 
-    if(dirent->file == NULL) {
+    if(dest == NULL) {
         jinue_error("error: could not allocate memory for file content");
         return -1;
     }
 
     size_t record_aligned_size = (dirent->size + RECORD_SIZE - 1) & ~((size_t)RECORD_SIZE - 1);
 
-    int status = stream_read(state->stream, (void *)dirent->file, record_aligned_size);
+    int status = stream_read(state->stream, dest, record_aligned_size);
 
     if(status != STREAM_SUCCESS) {
         jinue_error("error: read error while reading file content");
@@ -590,8 +590,10 @@ static int copy_file_data(state_t *state, jinue_dirent_t *dirent) {
 
     /* clear padding */
     if(page_aligned_size > dirent->size) {
-        memset((char *)dirent->file + dirent->size, 0, page_aligned_size - dirent->size);
+        memset((char *)dest + dirent->size, 0, page_aligned_size - dirent->size);
     }
+
+    dirent->file = (char *)dest - (char *)dirent;
 
     return 0;
 }
@@ -720,27 +722,32 @@ const jinue_dirent_t *tar_extract(stream_t *stream) {
             return NULL;
         }
 
-        dirent->name = copy_string(&state, filename);
+        const char *name = copy_string(&state, filename);
+
+        if(name == NULL) {
+            jinue_error("error: failed to allocate memory for string (for file name)");
+            return NULL;
+        }
+
+        dirent->name = name - (char *)dirent;
         dirent->size = DECODE_OCTAL_FIELD(header->size);
         dirent->uid  = DECODE_OCTAL_FIELD(header->uid);
         dirent->gid  = DECODE_OCTAL_FIELD(header->gid);
         dirent->mode = map_mode(DECODE_OCTAL_FIELD(header->mode));
 
-        if(dirent->name == NULL) {
-            jinue_error("error: failed to allocate memory for string (for file name)");
-            return NULL;
-        }
+        const char *link;
 
         switch(type) {
         case JINUE_DIRENT_TYPE_SYMLINK:
-            dirent->size    = 0;
-            dirent->link    = copy_fixed_string(&state, header->linkname, sizeof(header->linkname));
+            link = copy_fixed_string(&state, header->linkname, sizeof(header->linkname));
 
-            if(dirent->link == NULL) {
+            if(link == NULL) {
                 jinue_error("error: failed to allocate memory for string (for symbolic link)");
                 return NULL;
             }
 
+            dirent->size    = 0;
+            dirent->link    = link - (char *)dirent;
             break;
         case JINUE_DIRENT_TYPE_BLKDEV:
         case JINUE_DIRENT_TYPE_CHARDEV:

--- a/userspace/loader/archives/tar.c
+++ b/userspace/loader/archives/tar.c
@@ -593,7 +593,7 @@ static int copy_file_data(state_t *state, jinue_dirent_t *dirent) {
         memset((char *)dest + dirent->size, 0, page_aligned_size - dirent->size);
     }
 
-    dirent->file = (char *)dest - (char *)dirent;
+    dirent->rel_value = (char *)dest - (char *)dirent;
 
     return 0;
 }
@@ -729,11 +729,11 @@ const jinue_dirent_t *tar_extract(stream_t *stream) {
             return NULL;
         }
 
-        dirent->name = name - (char *)dirent;
-        dirent->size = DECODE_OCTAL_FIELD(header->size);
-        dirent->uid  = DECODE_OCTAL_FIELD(header->uid);
-        dirent->gid  = DECODE_OCTAL_FIELD(header->gid);
-        dirent->mode = map_mode(DECODE_OCTAL_FIELD(header->mode));
+        dirent->rel_name    = name - (char *)dirent;
+        dirent->size        = DECODE_OCTAL_FIELD(header->size);
+        dirent->uid         = DECODE_OCTAL_FIELD(header->uid);
+        dirent->gid         = DECODE_OCTAL_FIELD(header->gid);
+        dirent->mode        = map_mode(DECODE_OCTAL_FIELD(header->mode));
 
         const char *link;
 
@@ -746,8 +746,8 @@ const jinue_dirent_t *tar_extract(stream_t *stream) {
                 return NULL;
             }
 
-            dirent->size    = 0;
-            dirent->link    = link - (char *)dirent;
+            dirent->size        = 0;
+            dirent->rel_value   = link - (char *)dirent;
             break;
         case JINUE_DIRENT_TYPE_BLKDEV:
         case JINUE_DIRENT_TYPE_CHARDEV:

--- a/userspace/loader/binfmt/elf.c
+++ b/userspace/loader/binfmt/elf.c
@@ -421,8 +421,8 @@ size_t count_environ(void) {
  * 
  * */
 char *write_cmdline_arguments(char *dest, const jinue_dirent_t *dirent, int argc, char *argv[]) {
-    strcpy(dest, dirent->name);
-    dest += strlen(dirent->name) + 1;
+    strcpy(dest, jinue_dirent_name(dirent));
+    dest += strlen(jinue_dirent_name(dirent)) + 1;
 
     for(int idx = 1; idx < argc; ++ idx) {
         strcpy(dest, argv[idx]);
@@ -586,7 +586,7 @@ static void initialize_stack(
  *
  * */
 int load_elf(elf_info_t *elf_info, int fd, const jinue_dirent_t *dirent, int argc, char *argv[]) {
-    const Elf32_Ehdr *ehdr = dirent->file;
+    const Elf32_Ehdr *ehdr = jinue_dirent_file(dirent);
 
     int status = check_elf_header(ehdr, dirent->size);
 

--- a/userspace/loader/debug.c
+++ b/userspace/loader/debug.c
@@ -110,7 +110,7 @@ void dump_ramdisk(const jinue_dirent_t *root) {
                 dirent->uid,
                 dirent->gid,
                 dirent->size,
-                dirent->name
+                jinue_dirent_name(dirent)
         );
 
         dirent = jinue_dirent_get_next(dirent);

--- a/userspace/loader/debug.c
+++ b/userspace/loader/debug.c
@@ -32,6 +32,7 @@
 #include <jinue/jinue.h>
 #include <jinue/loader.h>
 #include <jinue/utils.h>
+#include <inttypes.h>
 #include "debug.h"
 #include "utils.h"
 
@@ -105,7 +106,7 @@ void dump_ramdisk(const jinue_dirent_t *root) {
 
     while(dirent != NULL) {
         jinue_info(
-                "  %s %6u %6u %12u %s",
+                "  %s %6" PRIu32 " %6" PRIu32 " %12" PRIu64 " %s",
                 pretty_mode(mode_buffer, dirent),
                 dirent->uid,
                 dirent->gid,

--- a/userspace/loader/loader.c
+++ b/userspace/loader/loader.c
@@ -81,7 +81,7 @@ static const jinue_dirent_t *get_init(const jinue_dirent_t *root) {
 }
 
 static int load_init(elf_info_t *elf_info, const jinue_dirent_t *init, int argc, char *argv[]) {
-    jinue_info("Loading init program %s", init->name);
+    jinue_info("Loading init program %s", jinue_dirent_name(init));
 
     int status = jinue_create_process(INIT_PROCESS_DESCRIPTOR, &errno);
 


### PR DESCRIPTION
Make extracted RAM disk relocatable by replacing pointers with relative offsets.

Rationale:

* We want the user space loader to pass the RAM disk location to the initial process so that process can map it in its own address space and use it.
* Future direction: we want to add the extracted RAM disk format as a supported RAM disk image format. Using this format uncompressed as the RAM disk image would allow the loader to use it in place so there wouldn't be two copies of the RAM disk in memory (original image + extracted). This would be useful for embedded systems with limited memory that run entirely off the initial RAM disk.