### PR TITLE
libc cleanup and naming convention

### DIFF
--- a/include/internals.h
+++ b/include/internals.h
@@ -46,4 +46,8 @@ int __allocate_descriptor(void);
 
 void __free_descriptor(int fd);
 
+void *__mmap_anonymous(void *addr, size_t len);
+
+#define mmap_anonymous __mmap_anonymous
+
 #endif

--- a/include/internals.h
+++ b/include/internals.h
@@ -36,17 +36,28 @@
 
 #define MMAP_BASE 0x40000000
 
-int _libc_init(void); 
+int __libc_init(void); 
 
-uint64_t _libc_get_physmem_alloc_addr(void);
+uint64_t __get_physmem_alloc_addr(void);
 
-uint64_t _libc_get_physmem_alloc_limit(void);
+uint64_t __get_physmem_alloc_limit(void);
 
 int __allocate_descriptor(void);
 
 void __free_descriptor(int fd);
 
 void *__mmap_anonymous(void *addr, size_t len);
+
+
+#define libc_init __libc_init
+
+#define libc_get_physmem_alloc_addr __get_physmem_alloc_addr
+
+#define libc_get_physmem_alloc_limit __get_physmem_alloc_limit
+
+#define libc_allocate_descriptor __allocate_descriptor
+
+#define libc_free_descriptor __free_descriptor
 
 #define mmap_anonymous __mmap_anonymous
 

--- a/userspace/lib/libc/brk.c
+++ b/userspace/lib/libc/brk.c
@@ -113,7 +113,7 @@ int __brk_perrno(void *addr, int *perrno) {
     if((uintptr_t)addr > (uintptr_t)allocated_break) {
         uintptr_t new_allocated = ((uintptr_t)addr + JINUE_PAGE_SIZE - 1) & ~(JINUE_PAGE_SIZE - 1);
         size_t size             = new_allocated - (uintptr_t)allocated_break;
-        intptr_t physaddr       = physmem_alloc(size);
+        intptr_t physaddr       = __physmem_alloc(size);
 
         if(physaddr < 0) {
             *perrno = ENOMEM;

--- a/userspace/lib/libc/i686/crt.asm
+++ b/userspace/lib/libc/i686/crt.asm
@@ -32,7 +32,7 @@
     bits 32
     
     extern environ
-    extern _libc_init
+    extern __libc_init
     extern main
     extern jinue_exit_thread
     extern _jinue_libc_auxv
@@ -81,9 +81,9 @@ _start:
     ; Set address of auxiliary vectors
     mov dword [_jinue_libc_auxv], edi
     
-    call _libc_init
+    call __libc_init
 
-    ; Check _libc_init() exit status, skip main() if non-zero 
+    ; Check __libc_init() exit status, skip main() if non-zero 
     or eax, eax
     jnz .exit
 

--- a/userspace/lib/libc/init.c
+++ b/userspace/lib/libc/init.c
@@ -46,7 +46,7 @@ int __libc_init(void) {
 
     __pthread_set_current(__pthread_main_thread);
 
-    ret = physmem_init();
+    ret = __physmem_init();
 
     if(ret != EXIT_SUCCESS) {
         return EXIT_FAILURE;

--- a/userspace/lib/libc/init.c
+++ b/userspace/lib/libc/init.c
@@ -36,7 +36,8 @@
 #include "brk.h"
 #include "physmem.h"
 
-int _libc_init(void) {
+/* This function is called by assembly language code. */
+int __libc_init(void) {
     int ret = jinue_init(getauxval(JINUE_AT_HOWSYSCALL), NULL);
 
     if(ret < 0) {

--- a/userspace/lib/libc/mmap.c
+++ b/userspace/lib/libc/mmap.c
@@ -140,3 +140,19 @@ void *__mmap_perrno(
 
     return addr;
 }
+
+void *__mmap_anonymous(void *addr, size_t len) {
+    return __mmap_anonymous_perrno(addr, len, &errno);
+}
+
+void *__mmap_anonymous_perrno(void *addr, size_t len, int *perrno) {
+    return __mmap_perrno(
+        addr,
+        len,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED | MAP_ANONYMOUS,
+        -1,
+        0,
+        perrno
+    );
+}

--- a/userspace/lib/libc/mmap.c
+++ b/userspace/lib/libc/mmap.c
@@ -117,7 +117,7 @@ void *__mmap_perrno(
     int64_t paddr;
 
     if(flags & MAP_ANONYMOUS) {
-        paddr = physmem_alloc(aligned_length);
+        paddr = __physmem_alloc(aligned_length);
 
         if(paddr < 0) {
             *perrno = ENOMEM;

--- a/userspace/lib/libc/mmap.h
+++ b/userspace/lib/libc/mmap.h
@@ -44,4 +44,6 @@ void *__mmap_perrno(
     off_t    off,
     int     *perrno);
 
+void *__mmap_anonymous_perrno(void *addr, size_t len, int *perrno);
+
 #endif

--- a/userspace/lib/libc/physmem.c
+++ b/userspace/lib/libc/physmem.c
@@ -140,10 +140,10 @@ int64_t physmem_alloc(size_t size) {
     return retval;
 }
 
-uint64_t _libc_get_physmem_alloc_addr(void) {
+uint64_t __get_physmem_alloc_addr(void) {
     return alloc_range.addr;
 }
 
-uint64_t _libc_get_physmem_alloc_limit(void) {
+uint64_t __get_physmem_alloc_limit(void) {
     return alloc_range.limit;
 }

--- a/userspace/lib/libc/physmem.c
+++ b/userspace/lib/libc/physmem.c
@@ -109,7 +109,7 @@ static int initialize_range_from_kernel_info(void) {
     return EXIT_SUCCESS;
 }
 
-int physmem_init(void) {
+int __physmem_init(void) {
     int status = initialize_range_from_loader_info();
 
     if(status >= 0) {
@@ -127,7 +127,7 @@ int physmem_init(void) {
     return initialize_range_from_kernel_info();
 }
 
-int64_t physmem_alloc(size_t size) {
+int64_t __physmem_alloc(size_t size) {
     uint64_t top = alloc_range.addr + size;
 
     if(top > alloc_range.limit) {

--- a/userspace/lib/libc/physmem.h
+++ b/userspace/lib/libc/physmem.h
@@ -35,8 +35,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-int physmem_init(void);
+int __physmem_init(void);
 
-int64_t physmem_alloc(size_t size);
+int64_t __physmem_alloc(size_t size);
 
 #endif

--- a/userspace/lib/libc/pthread/thread.c
+++ b/userspace/lib/libc/pthread/thread.c
@@ -92,16 +92,7 @@ static pthread_t allocate_thread(int *perrno) {
 }
 
 static void *allocate_stack(size_t stacksize, int *perrno) {
-    void *stack = __mmap_perrno(
-        NULL,
-        stacksize,
-        PROT_READ | PROT_WRITE,
-        MAP_SHARED | MAP_ANONYMOUS,
-        -1,
-        0,
-        perrno
-    );
-
+    void *stack = __mmap_anonymous_perrno(NULL, stacksize, perrno);
     return (stack == MAP_FAILED) ? NULL : stack;
 }
 

--- a/userspace/loader/archives/alloc.c
+++ b/userspace/loader/archives/alloc.c
@@ -31,6 +31,7 @@
 
 #include <jinue/jinue.h>
 #include <sys/mman.h>
+#include <internals.h>
 #include <string.h>
 #include "alloc.h"
 
@@ -52,13 +53,8 @@
  *
  * */
 void *allocate_page_aligned(size_t bytes) {
-    void *addr = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-    if(addr == MAP_FAILED) {
-        return NULL;
-    }
-
-    return addr;
+    void *addr = mmap_anonymous(NULL, bytes);
+    return (addr == MAP_FAILED) ? NULL : addr;
 }
 
 /**

--- a/userspace/loader/archives/tar.c
+++ b/userspace/loader/archives/tar.c
@@ -643,7 +643,7 @@ const int map_mode(int tar_mode) {
 int tar_extract(extracted_ramdisk_t *extracted, stream_t *stream) {
     state_t state;
 
-    const uint64_t extracted_start = _libc_get_physmem_alloc_addr();
+    const uint64_t extracted_start = libc_get_physmem_alloc_addr();
     
     jinue_dirent_t *root = initialize_state(&state, stream);
 
@@ -772,7 +772,7 @@ int tar_extract(extracted_ramdisk_t *extracted, stream_t *stream) {
         }
     }
 
-    const uint64_t extracted_end = _libc_get_physmem_alloc_addr();
+    const uint64_t extracted_end = libc_get_physmem_alloc_addr();
 
     extracted->physaddr = extracted_start;
     extracted->size     = extracted_end - extracted_start;

--- a/userspace/loader/core/mappings.c
+++ b/userspace/loader/core/mappings.c
@@ -61,7 +61,7 @@ void *map_anonymous(void *vaddr, size_t size, int perms) {
     uint64_t paddr = _libc_get_physmem_alloc_addr();
 
     /* Map into this process so we can set the contents. */
-    void *segment = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    void *segment = mmap_anonymous(NULL, size);
 
     if(segment == MAP_FAILED) {
         jinue_error("error: mmap() failed: %s", strerror(errno));

--- a/userspace/loader/core/mappings.c
+++ b/userspace/loader/core/mappings.c
@@ -58,7 +58,7 @@ int map_file(void *vaddr, size_t size, int segment_index, size_t offset, int per
 }
 
 void *map_anonymous(void *vaddr, size_t size, int perms) {
-    uint64_t paddr = _libc_get_physmem_alloc_addr();
+    uint64_t paddr = libc_get_physmem_alloc_addr();
 
     /* Map into this process so we can set the contents. */
     void *segment = mmap_anonymous(NULL, size);

--- a/userspace/loader/core/meminfo.c
+++ b/userspace/loader/core/meminfo.c
@@ -111,8 +111,8 @@ void add_meminfo_mapping(void *addr, size_t size, int segment_index, size_t offs
 }
 
 static void update_meminfo(void) {
-    meminfo.hints.physaddr  = _libc_get_physmem_alloc_addr();
-    meminfo.hints.physlimit = _libc_get_physmem_alloc_limit();
+    meminfo.hints.physaddr  = libc_get_physmem_alloc_addr();
+    meminfo.hints.physlimit = libc_get_physmem_alloc_limit();
 }
 
 static void update_buffers(void) {

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -129,10 +129,10 @@ void run_ipc_test(void) {
 
     jinue_info("Running threading and IPC test...");
 
-    int endpoint = __allocate_descriptor();
+    int endpoint = libc_allocate_descriptor();
 
     if(endpoint < 0) {
-        jinue_error("error: __allocate_descriptor() failed: %s", strerror(errno));
+        jinue_error("error: libc_allocate_descriptor() failed: %s", strerror(errno));
         return;
     }
 
@@ -143,10 +143,10 @@ void run_ipc_test(void) {
         return;
     }
 
-    client_endpoint = __allocate_descriptor();
+    client_endpoint = libc_allocate_descriptor();
 
     if(client_endpoint < 0) {
-        jinue_error("error: __allocate_descriptor() failed: %s", strerror(errno));
+        jinue_error("error: libc_allocate_descriptor() failed: %s", strerror(errno));
         return;
     }
 


### PR DESCRIPTION
* Make sure all symbols defined in the libc that are not part of the standard C library or POSIX start with two underscores.
* Define prettier aliases as macros for functions exposed in `<internals.h>`.
* `mmap_anonymous()`.
