### PR TITLE
Rename JOIN_THREAD to AWAIT_THREAD

### DIFF
--- a/doc/init-process.md
+++ b/doc/init-process.md
@@ -198,7 +198,7 @@ memory](syscalls/mmap.md) into the process' address space and to
 
 The main thread descriptor is a descriptor that references the initial
 thread in the process. It can be used, among other things, to
-[join](syscalls/join-thread.md) the initial thread from another thread.
+[await](syscalls/await-thread.md) the initial thread from another thread.
 
 ### Loader IPC Endpoint Descriptor
 

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -27,7 +27,7 @@
 | 18      | [DESTROY](destroy.md)                   | Destroy a Kernel Object              |
 | 19      | [MINT](mint.md)                         | Mint a Descriptor                    |
 | 20      | [START_THREAD](start-thread.md)         | Start a Thread                       |
-| 21      | [JOIN_THREAD](join-thread.md)           | Wait for a Thread to Exit            |
+| 21      | [AWAIT_THREAD](await-thread.md)         | Wait for a Thread to Exit            |
 | 22      | [REPLY_ERROR](reply-error.md)           | Reply to Message with an Error       !
 | 23-4095 | -                                       | Reserved                             |
 | 4096+   | [SEND](send.md)                         | Send Message                         |

--- a/doc/syscalls/await-thread.md
+++ b/doc/syscalls/await-thread.md
@@ -1,4 +1,4 @@
-# JOIN_THREAD - Wait for a Thread to Exit
+# AWAIT_THREAD - Wait for a Thread to Exit
 
 ## Description
 
@@ -9,7 +9,7 @@ and must not be the calling thread. Furthermore, this function must be called
 at most once on a given thread since it has been started.
 
 For this operation to succeed, the thread descriptor must have the
-[JINUE_PERM_JOIN](../../include/jinue/shared/asm/permissions.h) permission.
+[JINUE_PERM_AWAIT](../../include/jinue/shared/asm/permissions.h) permission.
 
 ## Arguments
 
@@ -48,7 +48,7 @@ returns -1 and an error number is set (in `arg1`).
 
 * JINUE_EBADF if the thread descriptor is invalid, or does not refer to a
 thread, or is closed.
-* JINUE_ESRCH if the thread has not been started or has already beed joined.
-* JINUE_EDEADLK if a thread attempts to join itself.
+* JINUE_ESRCH if the thread has not been started or has already beed awaited.
+* JINUE_EDEADLK if a thread attempts to await itself.
 * JINUE_EPERM if the specified thread descriptor does not have the permission
-to join the thread.
+to await the thread.

--- a/doc/syscalls/mint.md
+++ b/doc/syscalls/mint.md
@@ -40,7 +40,7 @@ be specified:
 | Name              | Description                       |
 |-------------------|-----------------------------------|
 | JINUE_PERM_START  | Start the thread                  |
-| JINUE_PERM_JOIN   | Wait for the thread to terminate  |
+| JINUE_PERM_AWAIT   | Wait for the thread to terminate  |
 
 Other permission flags are reserved.
 

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -49,8 +49,6 @@ int jinue_init(int implementation, int *perrno);
 
 uintptr_t jinue_syscall(jinue_syscall_args_t *args);
 
-void jinue_thread_entry(void);
-
 void jinue_reboot(void);
 
 void jinue_set_thread_local(void *addr, size_t size);
@@ -117,7 +115,7 @@ int jinue_mint(
 
 int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno);
 
-int jinue_join_thread(int fd, int *perrno);
+int jinue_await_thread(int fd, int *perrno);
 
 int jinue_reply_error(uintptr_t errcode, int *perrno);
 

--- a/include/jinue/shared/asm/permissions.h
+++ b/include/jinue/shared/asm/permissions.h
@@ -50,7 +50,7 @@
 /** start a thread */
 #define JINUE_PERM_START            (1<<5)
 
-/** join a thread */
-#define JINUE_PERM_JOIN             (1<<6)
+/** await a thread */
+#define JINUE_PERM_AWAIT            (1<<6)
 
 #endif

--- a/include/jinue/shared/asm/syscalls.h
+++ b/include/jinue/shared/asm/syscalls.h
@@ -90,7 +90,7 @@
 #define JINUE_SYS_START_THREAD          20
 
 /** wait for a thread to exit */
-#define JINUE_SYS_JOIN_THREAD           21
+#define JINUE_SYS_AWAIT_THREAD          21
 
 /** reply to current message with an error code */
 #define JINUE_SYS_REPLY_ERROR           22

--- a/include/kernel/application/syscalls.h
+++ b/include/kernel/application/syscalls.h
@@ -34,6 +34,8 @@
 
 #include <kernel/types.h>
 
+int await_thread(int fd);
+
 int close(int fd);
 
 int create_endpoint(int fd);
@@ -51,8 +53,6 @@ void exit_thread(void);
 void *get_thread_local(void);
 
 int get_user_memory(const jinue_buffer_t *buffer);
-
-int join_thread(int fd);
 
 int mclone(int src, int dest, const jinue_mclone_args_t *args);
 

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -108,7 +108,7 @@ struct thread_t {
     thread_state_t           state;
     process_t               *process;
     struct thread_t         *sender;
-    struct thread_t         *joined;
+    struct thread_t         *awaiter;
     addr_t                   local_storage_addr;
     size_t                   local_storage_size;
     size_t                   recv_buffer_size;

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -69,7 +69,7 @@ sources.kernel.c = \
 	application/syscalls/exit_thread.c \
 	application/syscalls/get_thread_local.c \
 	application/syscalls/get_user_memory.c \
-	application/syscalls/join_thread.c \
+	application/syscalls/await_thread.c \
 	application/syscalls/mint.c \
 	application/syscalls/mmap.c \
 	application/syscalls/mclone.c \

--- a/kernel/application/syscalls/await_thread.c
+++ b/kernel/application/syscalls/await_thread.c
@@ -37,7 +37,7 @@
 #include <kernel/domain/entities/thread.h>
 #include <kernel/machine/thread.h>
 
-int join_thread(int fd) {
+int await_thread(int fd) {
     descriptor_t *desc;
     int status = dereference_object_descriptor(&desc, get_current_process(), fd);
 
@@ -51,7 +51,7 @@ int join_thread(int fd) {
         return -JINUE_EBADF;
     }
 
-    if(!descriptor_has_permissions(desc, JINUE_PERM_JOIN)) {
+    if(!descriptor_has_permissions(desc, JINUE_PERM_AWAIT)) {
         return -JINUE_EPERM;
     }
 
@@ -61,11 +61,11 @@ int join_thread(int fd) {
         return -JINUE_EDEADLK;
     }
 
-    if(thread->joined != NULL) {
+    if(thread->awaiter != NULL) {
         return -JINUE_ESRCH;
     }
 
-    thread->joined = current;
+    thread->awaiter = current;
 
     /* Keep the thread around until we actually read the exit value. */
     add_ref_to_object(&thread->header);

--- a/kernel/application/syscalls/await_thread.c
+++ b/kernel/application/syscalls/await_thread.c
@@ -61,6 +61,7 @@ int await_thread(int fd) {
         return -JINUE_EDEADLK;
     }
 
+    /* TODO this check and the following assignment should be atomic */
     if(thread->awaiter != NULL) {
         return -JINUE_ESRCH;
     }

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -42,8 +42,8 @@ void exit_thread(void) {
         thread->sender = NULL;
     }
 
-    if(thread->joined != NULL) {
-        ready_thread(thread->joined);
+    if(thread->awaiter != NULL) {
+        ready_thread(thread->awaiter);
     }
 
     /* This call must be the last thing happening in this function. */

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -42,7 +42,7 @@ static void free_thread(object_header_t *object);
 
 /** runtime type definition for a thread */
 static const object_type_t object_type = {
-    .all_permissions    = JINUE_PERM_START | JINUE_PERM_JOIN,
+    .all_permissions    = JINUE_PERM_START | JINUE_PERM_AWAIT,
     .name               = "thread",
     .size               = sizeof(thread_t),
     .open               = NULL,
@@ -71,10 +71,10 @@ thread_t *construct_thread(process_t *process) {
     thread->state               = THREAD_STATE_ZOMBIE;
     thread->process             = process;
     /* Arbitrary non-NULL value to signify the thread hasn't run yet and
-     * shouldn't be joined. This will fall in the condition in thread_join()
-     * that detects an attempt to join a thread that has already been joined,
-     * so thread_join() will fail with JINUE_ESRCH. */
-    thread->joined              = thread;
+     * shouldn't be awaited. This will fall in the condition in await_thread()
+     * that detects an attempt to await a thread that has already been awaited,
+     * so await_thread() will fail with JINUE_ESRCH. */
+    thread->awaiter             = thread;
     thread->local_storage_addr  = NULL;
     thread->local_storage_size  = 0;
  
@@ -87,8 +87,8 @@ static void free_thread(object_header_t *object) {
 }
 
 void prepare_thread(thread_t *thread, const thread_params_t *params) {
-    thread->sender = NULL;
-    thread->joined = NULL;
+    thread->sender  = NULL;
+    thread->awaiter = NULL;
     machine_prepare_thread(thread, params);
 }
 

--- a/kernel/interface/syscalls.c
+++ b/kernel/interface/syscalls.c
@@ -548,7 +548,7 @@ static void sys_start_thread(jinue_syscall_args_t *args) {
     set_return_value_or_error(args, retval);
 }
 
-static void sys_join_thread(jinue_syscall_args_t *args) {
+static void sys_await_thread(jinue_syscall_args_t *args) {
     int fd                      = get_descriptor(args->arg1);
 
     if(fd < 0) {
@@ -556,7 +556,7 @@ static void sys_join_thread(jinue_syscall_args_t *args) {
         return;
     }
 
-    int retval = join_thread(fd);
+    int retval = await_thread(fd);
     set_return_value_or_error(args, retval);
 }
 
@@ -641,8 +641,8 @@ void dispatch_syscall(jinue_syscall_args_t *args) {
         case JINUE_SYS_START_THREAD:
             sys_start_thread(args);
             break;
-        case JINUE_SYS_JOIN_THREAD:
-            sys_join_thread(args);
+        case JINUE_SYS_AWAIT_THREAD:
+            sys_await_thread(args);
             break;
         case JINUE_SYS_REPLY_ERROR:
             sys_reply_error(args);

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -342,10 +342,10 @@ int jinue_start_thread(int fd, void (*entry)(void), void *stack, int *perrno) {
     return call_with_usual_convention(&args, perrno);
 }
 
-int jinue_join_thread(int fd, int *perrno) {
+int jinue_await_thread(int fd, int *perrno) {
     jinue_syscall_args_t args;
 
-    args.arg0 = JINUE_SYS_JOIN_THREAD;
+    args.arg0 = JINUE_SYS_AWAIT_THREAD;
     args.arg1 = fd;
     args.arg2 = 0;
     args.arg3 = 0;

--- a/userspace/lib/libc/pthread/thread.c
+++ b/userspace/lib/libc/pthread/thread.c
@@ -175,7 +175,7 @@ int pthread_create(
 
 int pthread_join(pthread_t thread, void **exit_status) {
     int errno_retval;
-    int status = jinue_join_thread(thread->fd, &errno_retval);
+    int status = jinue_await_thread(thread->fd, &errno_retval);
 
     if(status < 0) {
         return errno_retval;

--- a/userspace/loader/loader.c
+++ b/userspace/loader/loader.c
@@ -155,7 +155,7 @@ static int load_init(
         INIT_THREAD_DESCRIPTOR,
         INIT_PROCESS_DESCRIPTOR,
         JINUE_DESC_MAIN_THREAD,
-        JINUE_PERM_START | JINUE_PERM_JOIN,
+        JINUE_PERM_START | JINUE_PERM_AWAIT,
         0,
         &errno
     );


### PR DESCRIPTION
Rename `JOIN_THREAD` system call to `AWAIT_THREAD`: the system call performs the awaiting part of `pthread_join()` but does not deal with the exit status so it's more of a call upon which `pthread_join()` is built rather than a system call thinly wrapped by this function, so there is no real need to follow the same naming. Await is more descriptive of what it does than "join".