### PR TITLE
Rename entity functions

### DIFF
--- a/include/kernel/domain/entities/descriptor.h
+++ b/include/kernel/domain/entities/descriptor.h
@@ -85,27 +85,27 @@ static inline bool descriptor_has_permissions(const descriptor_t *desc, int perm
     return (desc->flags & perms) == perms;
 }
 
-void clear_descriptor(descriptor_t *desc);
+void descriptor_clear(descriptor_t *desc);
 
-int dereference_object_descriptor(
+int descriptor_access_object(
         descriptor_t    *pout,
         process_t       *process,
         int              fd);
 
-void unreference_descriptor_object(descriptor_t *desc);
+void descriptor_unreference_object(descriptor_t *desc);
 
-int reserve_free_descriptor(process_t *process, int fd);
+int descriptor_reserve_unused(process_t *process, int fd);
 
-void free_reserved_descriptor(process_t *process, int fd);
+void descriptor_free_reservation(process_t *process, int fd);
 
-void open_descriptor(process_t *process, int fd, const descriptor_t *in);
+void descriptor_open(process_t *process, int fd, const descriptor_t *in);
 
-int close_descriptor(process_t *process, int fd);
+int descriptor_close(process_t *process, int fd);
 
-ipc_endpoint_t *get_endpoint_from_descriptor(descriptor_t *desc);
+ipc_endpoint_t *descriptor_get_endpoint(descriptor_t *desc);
 
-process_t *get_process_from_descriptor(descriptor_t *desc);
+process_t *descriptor_get_process(descriptor_t *desc);
 
-thread_t *get_thread_from_descriptor(descriptor_t *desc);
+thread_t *descriptor_get_thread(descriptor_t *desc);
 
 #endif

--- a/include/kernel/domain/entities/endpoint.h
+++ b/include/kernel/domain/entities/endpoint.h
@@ -42,6 +42,6 @@ static inline object_header_t *endpoint_object(ipc_endpoint_t *endpoint) {
 
 void initialize_endpoint_cache(void);
 
-ipc_endpoint_t *construct_endpoint(void);
+ipc_endpoint_t *endpoint_new(void);
 
 #endif

--- a/include/kernel/domain/entities/object.h
+++ b/include/kernel/domain/entities/object.h
@@ -44,7 +44,7 @@ static inline bool object_is_destroyed(object_header_t *object) {
     return !!(object->flags & OBJECT_FLAG_DESTROYED);
 }
 
-static inline void init_object_header(object_header_t *object, const object_type_t *type) {
+static inline void object_init_header(object_header_t *object, const object_type_t *type) {
     object->type        = type;
     object->ref_count   = 0;
     object->flags       = OBJECT_FLAG_NONE;
@@ -52,14 +52,14 @@ static inline void init_object_header(object_header_t *object, const object_type
 
 void init_object_cache(slab_cache_t *cache, const object_type_t *type);
 
-void open_object(object_header_t *object, const descriptor_t *desc);
+void object_open(object_header_t *object, const descriptor_t *desc);
 
-void close_object(object_header_t *object, const descriptor_t *desc);
+void object_close(object_header_t *object, const descriptor_t *desc);
 
-void destroy_object(object_header_t *object);
+void object_destroy(object_header_t *object);
 
-void add_ref_to_object(object_header_t *object);
+void object_add_ref(object_header_t *object);
 
-void sub_ref_to_object(object_header_t *object);
+void object_sub_ref(object_header_t *object);
 
 #endif

--- a/include/kernel/domain/entities/process.h
+++ b/include/kernel/domain/entities/process.h
@@ -42,14 +42,14 @@ static inline object_header_t *process_object(process_t *process) {
 
 void initialize_process_cache(void);
 
-process_t *construct_process(void);
-
-void switch_to_process(process_t *process);
-
 process_t *get_current_process(void);
 
-void add_running_thread_to_process(process_t *process);
+process_t *process_new(void);
 
-void remove_running_thread_from_process(process_t *process);
+void process_switch_to(process_t *process);
+
+void process_add_running_thread(process_t *process);
+
+void process_remove_running_thread(process_t *process);
 
 #endif

--- a/include/kernel/domain/entities/thread.h
+++ b/include/kernel/domain/entities/thread.h
@@ -40,26 +40,26 @@ static inline object_header_t *thread_object(thread_t *thread) {
     return &thread->header;
 }
 
-thread_t *construct_thread(process_t *process);
+thread_t *thread_new(process_t *process);
 
-void prepare_thread(thread_t *thread, const thread_params_t *params);
+void thread_prepare(thread_t *thread, const thread_params_t *params);
 
-void ready_thread(thread_t *thread);
+void thread_ready(thread_t *thread);
 
-void run_first_thread(thread_t *thread);
+void thread_run_first(thread_t *thread);
 
-void run_thread(thread_t *thread);
+void thread_run(thread_t *thread);
 
-void terminate_current_thread(void);
+void thread_terminate_current(void);
 
-void switch_to(thread_t *to);
+void thread_switch_to(thread_t *to);
 
-void switch_to_and_block(thread_t *to);
+void thread_switch_to_and_block(thread_t *to);
 
-void block_and_unlock(spinlock_t *lock);
+void thread_block_current_and_unlock(spinlock_t *lock);
 
-void yield_current_thread(void);
+void thread_yield_current(void);
 
-void set_thread_local_storage(thread_t *thread, addr_t addr, size_t size);
+void thread_set_local_storage(thread_t *thread, addr_t addr, size_t size);
 
 #endif

--- a/kernel/application/kmain.c
+++ b/kernel/application/kmain.c
@@ -85,13 +85,13 @@ void kmain(const char *cmdline) {
     initialize_process_cache();
 
     /* create process for user space loader */
-    process_t *process = construct_process();
+    process_t *process = process_new();
 
     if(process == NULL) {
         panic("Could not create initial process.");
     }
 
-    switch_to_process(process);
+    process_switch_to(process);
 
     /* create user space loader main thread */
     thread_t *thread = construct_thread(process);

--- a/kernel/application/kmain.c
+++ b/kernel/application/kmain.c
@@ -94,7 +94,7 @@ void kmain(const char *cmdline) {
     process_switch_to(process);
 
     /* create user space loader main thread */
-    thread_t *thread = construct_thread(process);
+    thread_t *thread = thread_new(process);
 
     if(thread == NULL) {
         panic("Could not create initial thread.");
@@ -117,8 +117,8 @@ void kmain(const char *cmdline) {
     info("---");
 
     /* Start first thread. */
-    run_first_thread(thread);
+    thread_run_first(thread);
 
     /* should never happen */
-    panic("run_first_thread() returned in kmain()");
+    panic("thread_run_first() returned in kmain()");
 }

--- a/kernel/application/syscalls/await_thread.c
+++ b/kernel/application/syscalls/await_thread.c
@@ -67,7 +67,7 @@ static int with_thread(descriptor_t *thread_desc) {
     if(thread->state == THREAD_STATE_ZOMBIE) {
         spin_unlock(&thread->await_lock);
     } else {
-        block_and_unlock(&thread->await_lock);
+        thread_block_current_and_unlock(&thread->await_lock);
     }
 
     return 0;

--- a/kernel/application/syscalls/await_thread.c
+++ b/kernel/application/syscalls/await_thread.c
@@ -39,7 +39,7 @@
 #include <kernel/machine/thread.h>
 
 static int with_thread(descriptor_t *thread_desc) {
-    thread_t *thread = get_thread_from_descriptor(thread_desc);
+    thread_t *thread = descriptor_get_thread(thread_desc);
 
     if(thread == NULL) {
         return -JINUE_EBADF;
@@ -75,7 +75,7 @@ static int with_thread(descriptor_t *thread_desc) {
 
 int await_thread(int fd) {
     descriptor_t thread_desc;
-    int status = dereference_object_descriptor(&thread_desc, get_current_process(), fd);
+    int status = descriptor_access_object(&thread_desc, get_current_process(), fd);
 
     if(status < 0) {
         return -JINUE_EBADF;
@@ -83,7 +83,7 @@ int await_thread(int fd) {
 
     status = with_thread(&thread_desc);
 
-    unreference_descriptor_object(&thread_desc);
+    descriptor_unreference_object(&thread_desc);
 
     return status;
 }

--- a/kernel/application/syscalls/close.c
+++ b/kernel/application/syscalls/close.c
@@ -37,5 +37,5 @@
 
 
 int close(int fd) {
-    return close_descriptor(get_current_process(), fd);
+    return descriptor_close(get_current_process(), fd);
 }

--- a/kernel/application/syscalls/create_endpoint.c
+++ b/kernel/application/syscalls/create_endpoint.c
@@ -53,7 +53,7 @@ int create_endpoint(int fd) {
         return status;
     }
 
-    ipc_endpoint_t *endpoint = construct_endpoint();
+    ipc_endpoint_t *endpoint = endpoint_new();
 
     if(endpoint == NULL) {
         descriptor_free_reservation(process, fd);

--- a/kernel/application/syscalls/create_endpoint.c
+++ b/kernel/application/syscalls/create_endpoint.c
@@ -47,7 +47,7 @@
  */
 int create_endpoint(int fd) {
     process_t *process  = get_current_process();
-    int status          = reserve_free_descriptor(process, fd);
+    int status          = descriptor_reserve_unused(process, fd);
 
     if(status < 0) {
         return status;
@@ -56,7 +56,7 @@ int create_endpoint(int fd) {
     ipc_endpoint_t *endpoint = construct_endpoint();
 
     if(endpoint == NULL) {
-        free_reserved_descriptor(process, fd);
+        descriptor_free_reservation(process, fd);
         return -JINUE_EAGAIN;
     }
 
@@ -65,7 +65,7 @@ int create_endpoint(int fd) {
     desc.flags  = DESC_FLAG_OWNER | object_type_ipc_endpoint->all_permissions;
     desc.cookie = 0;
 
-    open_descriptor(process, fd, &desc);
+    descriptor_open(process, fd, &desc);
 
     return 0;
 }

--- a/kernel/application/syscalls/create_process.c
+++ b/kernel/application/syscalls/create_process.c
@@ -43,7 +43,7 @@ int create_process(int fd) {
         return status;
     }
 
-    process_t *new_process = construct_process();
+    process_t *new_process = process_new();
 
     if(new_process == NULL) {
         descriptor_free_reservation(current, fd);

--- a/kernel/application/syscalls/create_process.c
+++ b/kernel/application/syscalls/create_process.c
@@ -37,7 +37,7 @@
 
 int create_process(int fd) {
     process_t *current  = get_current_process();
-    int status          = reserve_free_descriptor(current, fd);
+    int status          = descriptor_reserve_unused(current, fd);
 
     if(status < 0) {
         return status;
@@ -46,7 +46,7 @@ int create_process(int fd) {
     process_t *new_process = construct_process();
 
     if(new_process == NULL) {
-        free_reserved_descriptor(current, fd);
+        descriptor_free_reservation(current, fd);
         return -JINUE_EAGAIN;
     }
 
@@ -55,7 +55,7 @@ int create_process(int fd) {
     desc.flags  = DESC_FLAG_OWNER | object_type_process->all_permissions;
     desc.cookie = 0;
 
-    open_descriptor(current, fd, &desc);
+    descriptor_open(current, fd, &desc);
 
     return 0;
 }

--- a/kernel/application/syscalls/create_thread.c
+++ b/kernel/application/syscalls/create_thread.c
@@ -48,7 +48,7 @@ static int with_target_process(process_t *current, int fd, descriptor_t *target_
         return -JINUE_EPERM;
     }
 
-    thread_t *thread = construct_thread(target);
+    thread_t *thread = thread_new(target);
 
     if(thread == NULL) {
         return -JINUE_ENOMEM;

--- a/kernel/application/syscalls/destroy.c
+++ b/kernel/application/syscalls/destroy.c
@@ -40,7 +40,7 @@ int destroy(int fd) {
     process_t *process = get_current_process();
 
     descriptor_t desc;
-    int status = dereference_object_descriptor(&desc, process, fd);
+    int status = descriptor_access_object(&desc, process, fd);
 
     if(status < 0) {
         return status;
@@ -50,18 +50,18 @@ int destroy(int fd) {
 
     /* TODO support other object types */
     if(object->type != object_type_ipc_endpoint) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EBADF;
     }
 
     if(!descriptor_is_owner(&desc)) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EPERM;
     }
 
     destroy_object(object);
 
-    unreference_descriptor_object(&desc);
+    descriptor_unreference_object(&desc);
 
     return 0;
 }

--- a/kernel/application/syscalls/destroy.c
+++ b/kernel/application/syscalls/destroy.c
@@ -59,7 +59,7 @@ int destroy(int fd) {
         return -JINUE_EPERM;
     }
 
-    destroy_object(object);
+    object_destroy(object);
 
     descriptor_unreference_object(&desc);
 

--- a/kernel/application/syscalls/dup.c
+++ b/kernel/application/syscalls/dup.c
@@ -46,13 +46,13 @@ static int with_source(
         return -JINUE_EBADF;
     }
 
-    int status = reserve_free_descriptor(target, dest);
+    int status = descriptor_reserve_unused(target, dest);
 
     if(status < 0) {
         return status;
     }
 
-    open_descriptor(target, dest, src_desc);
+    descriptor_open(target, dest, src_desc);
 
     return 0;
 }
@@ -63,7 +63,7 @@ static int with_target_process(
         int              src,
         int              dest) {
     
-    process_t *target = get_process_from_descriptor(target_desc);
+    process_t *target = descriptor_get_process(target_desc);
 
     if(target == NULL) {
         return -JINUE_EBADF;
@@ -74,7 +74,7 @@ static int with_target_process(
     }
 
     descriptor_t src_desc;
-    int status = dereference_object_descriptor(&src_desc, current, src);
+    int status = descriptor_access_object(&src_desc, current, src);
 
     if(status < 0) {
         return status;
@@ -82,7 +82,7 @@ static int with_target_process(
 
     status = with_source(current, target, &src_desc, dest);
 
-    unreference_descriptor_object(&src_desc);
+    descriptor_unreference_object(&src_desc);
 
     return status;
 }
@@ -91,7 +91,7 @@ int dup(int process_fd, int src, int dest) {
     process_t *current = get_current_process();
 
     descriptor_t target_desc;
-    int status = dereference_object_descriptor(&target_desc, current, process_fd);
+    int status = descriptor_access_object(&target_desc, current, process_fd);
     
     if(status < 0) {
         return status;
@@ -99,7 +99,7 @@ int dup(int process_fd, int src, int dest) {
 
     status = with_target_process(current, &target_desc, src, dest);
 
-    unreference_descriptor_object(&target_desc);
+    descriptor_unreference_object(&target_desc);
 
     return status;
 }

--- a/kernel/application/syscalls/exit_thread.c
+++ b/kernel/application/syscalls/exit_thread.c
@@ -33,5 +33,5 @@
 #include <kernel/domain/entities/thread.h>
 
 void exit_thread(void) {
-    terminate_current_thread();
+    thread_terminate_current();
 }

--- a/kernel/application/syscalls/mclone.c
+++ b/kernel/application/syscalls/mclone.c
@@ -42,7 +42,7 @@ static int with_destination(
         descriptor_t                *dest_desc,
         const jinue_mclone_args_t   *args) {
 
-    process_t *dest_process = get_process_from_descriptor(dest_desc);
+    process_t *dest_process = descriptor_get_process(dest_desc);
 
     if(dest_process == NULL) {
         return -JINUE_EBADF;
@@ -74,7 +74,7 @@ static int with_source(
         int                          dest,
         const jinue_mclone_args_t   *args) {
     
-    process_t *src_process = get_process_from_descriptor(src_desc);
+    process_t *src_process = descriptor_get_process(src_desc);
 
     if(src_process == NULL) {
         return -JINUE_EBADF;
@@ -84,7 +84,7 @@ static int with_source(
      * source just implicitly be the current process? */
 
     descriptor_t dest_desc;
-    int status = dereference_object_descriptor(&dest_desc, current, dest);
+    int status = descriptor_access_object(&dest_desc, current, dest);
     
     if(status < 0) {
         return status;
@@ -92,7 +92,7 @@ static int with_source(
 
     status = with_destination(current, src_process, &dest_desc, args);
 
-    unreference_descriptor_object(&dest_desc);
+    descriptor_unreference_object(&dest_desc);
 
     return status;
 }
@@ -111,7 +111,7 @@ int mclone(int src, int dest, const jinue_mclone_args_t *args) {
     process_t *current = get_current_process();
 
     descriptor_t src_desc;
-    int status = dereference_object_descriptor(&src_desc, current, src);
+    int status = descriptor_access_object(&src_desc, current, src);
     
     if(status < 0) {
         return status;
@@ -119,7 +119,7 @@ int mclone(int src, int dest, const jinue_mclone_args_t *args) {
     
     status = with_source(current, &src_desc, dest, args);
 
-    unreference_descriptor_object(&src_desc);
+    descriptor_unreference_object(&src_desc);
 
     return status;
 }

--- a/kernel/application/syscalls/mint.c
+++ b/kernel/application/syscalls/mint.c
@@ -41,7 +41,7 @@ static int with_target_process(
         descriptor_t            *target_desc,
         const jinue_mint_args_t *args) {
     
-    process_t *target = get_process_from_descriptor(target_desc);
+    process_t *target = descriptor_get_process(target_desc);
 
     if(target == NULL) {
         return -JINUE_EBADF;
@@ -51,7 +51,7 @@ static int with_target_process(
         return -JINUE_EPERM;
     }
 
-    int status = reserve_free_descriptor(target, args->fd);
+    int status = descriptor_reserve_unused(target, args->fd);
 
     if(status < 0) {
         return status;
@@ -62,7 +62,7 @@ static int with_target_process(
     dest_desc.flags  = args->perms;
     dest_desc.cookie = args->cookie;
 
-    open_descriptor(target, args->fd, &dest_desc);
+    descriptor_open(target, args->fd, &dest_desc);
 
     return 0;
 }
@@ -88,7 +88,7 @@ static int with_owner(
     }
 
     descriptor_t target_desc;
-    int status = dereference_object_descriptor(&target_desc, current, args->process);
+    int status = descriptor_access_object(&target_desc, current, args->process);
 
     if(status < 0) {
         return status;
@@ -96,7 +96,7 @@ static int with_owner(
 
     status = with_target_process(current, owner_desc, &target_desc, args);
 
-    unreference_descriptor_object(&target_desc);
+    descriptor_unreference_object(&target_desc);
 
     return status;
 }
@@ -105,7 +105,7 @@ int mint(int owner, const jinue_mint_args_t *args) {
     process_t *current = get_current_process();
 
     descriptor_t owner_desc;
-    int status = dereference_object_descriptor(&owner_desc, current, owner);
+    int status = descriptor_access_object(&owner_desc, current, owner);
 
     if(status < 0) {
         return status;
@@ -113,7 +113,7 @@ int mint(int owner, const jinue_mint_args_t *args) {
 
     status = with_owner(current, &owner_desc, args);
 
-    unreference_descriptor_object(&owner_desc);
+    descriptor_unreference_object(&owner_desc);
 
     return status;
 }

--- a/kernel/application/syscalls/mmap.c
+++ b/kernel/application/syscalls/mmap.c
@@ -36,7 +36,7 @@
 #include <kernel/machine/pmap.h>
 
 int with_process(descriptor_t *process_desc, const jinue_mmap_args_t *args) {
-    process_t *process = get_process_from_descriptor(process_desc);
+    process_t *process = descriptor_get_process(process_desc);
 
     if(process == NULL) {
         return -JINUE_EBADF;
@@ -56,7 +56,7 @@ int with_process(descriptor_t *process_desc, const jinue_mmap_args_t *args) {
 
 int mmap(int process_fd, const jinue_mmap_args_t *args) {
     descriptor_t process_desc;
-    int status = dereference_object_descriptor(&process_desc, get_current_process(), process_fd);
+    int status = descriptor_access_object(&process_desc, get_current_process(), process_fd);
 
     if(status < 0) {
         return status;
@@ -64,7 +64,7 @@ int mmap(int process_fd, const jinue_mmap_args_t *args) {
 
     status = with_process(&process_desc, args);
 
-    unreference_descriptor_object(&process_desc);
+    descriptor_unreference_object(&process_desc);
 
     return status;
 }

--- a/kernel/application/syscalls/receive.c
+++ b/kernel/application/syscalls/receive.c
@@ -40,27 +40,27 @@ int receive(int fd, jinue_message_t *message) {
     thread_t *receiver = get_current_thread();
 
     descriptor_t desc;
-    int status = dereference_object_descriptor(&desc, receiver->process, fd);
+    int status = descriptor_access_object(&desc, receiver->process, fd);
 
     if(status < 0) {
         return status;
     }
 
-    ipc_endpoint_t *endpoint = get_endpoint_from_descriptor(&desc);
+    ipc_endpoint_t *endpoint = descriptor_get_endpoint(&desc);
 
     if(endpoint == NULL) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EBADF;
     }
 
     if(!descriptor_has_permissions(&desc, JINUE_PERM_RECEIVE)) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EPERM;
     }
 
     status = receive_message(endpoint, receiver, message);
 
-    unreference_descriptor_object(&desc);
+    descriptor_unreference_object(&desc);
 
     return status;
 }

--- a/kernel/application/syscalls/send.c
+++ b/kernel/application/syscalls/send.c
@@ -40,27 +40,27 @@ int send(uintptr_t *errcode, int fd, int function, const jinue_message_t *messag
     thread_t *sender = get_current_thread();
 
     descriptor_t desc;
-    int status = dereference_object_descriptor(&desc, sender->process, fd);
+    int status = descriptor_access_object(&desc, sender->process, fd);
 
     if(status < 0) {
         return status;
     }
 
-    ipc_endpoint_t *endpoint = get_endpoint_from_descriptor(&desc);
+    ipc_endpoint_t *endpoint = descriptor_get_endpoint(&desc);
 
     if(endpoint == NULL) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EBADF;
     }
 
     if(!descriptor_has_permissions(&desc, JINUE_PERM_SEND)) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EPERM;
     }
 
     status = send_message(errcode, endpoint, sender, function, desc.cookie, message);
 
-    unreference_descriptor_object(&desc);
+    descriptor_unreference_object(&desc);
 
     return status;
 }

--- a/kernel/application/syscalls/set_thread_local.c
+++ b/kernel/application/syscalls/set_thread_local.c
@@ -34,5 +34,5 @@
 #include <kernel/machine/thread.h>
 
 void set_thread_local(void *addr, size_t size) {
-    set_thread_local_storage(get_current_thread(), addr, size);
+    thread_set_local_storage(get_current_thread(), addr, size);
 }

--- a/kernel/application/syscalls/start_thread.c
+++ b/kernel/application/syscalls/start_thread.c
@@ -60,9 +60,9 @@ int start_thread(int fd, const thread_params_t *params) {
         return -JINUE_EBUSY;
     }
 
-    prepare_thread(thread, params);
+    thread_prepare(thread, params);
 
-    run_thread(thread);
+    thread_run(thread);
 
     descriptor_unreference_object(&desc);
 

--- a/kernel/application/syscalls/start_thread.c
+++ b/kernel/application/syscalls/start_thread.c
@@ -37,26 +37,26 @@
 
 int start_thread(int fd, const thread_params_t *params) {
     descriptor_t desc;
-    int status = dereference_object_descriptor(&desc, get_current_process(), fd);
+    int status = descriptor_access_object(&desc, get_current_process(), fd);
 
     if(status < 0) {
         return -JINUE_EBADF;
     }
 
-    thread_t *thread = get_thread_from_descriptor(&desc);
+    thread_t *thread = descriptor_get_thread(&desc);
 
     if(thread == NULL) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EBADF;
     }
 
     if(!descriptor_has_permissions(&desc, JINUE_PERM_START)) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EPERM;
     }
 
     if(thread->state != THREAD_STATE_CREATED && thread->state != THREAD_STATE_ZOMBIE) {
-        unreference_descriptor_object(&desc);
+        descriptor_unreference_object(&desc);
         return -JINUE_EBUSY;
     }
 
@@ -64,7 +64,7 @@ int start_thread(int fd, const thread_params_t *params) {
 
     run_thread(thread);
 
-    unreference_descriptor_object(&desc);
+    descriptor_unreference_object(&desc);
 
     return 0;
 }

--- a/kernel/application/syscalls/yield_thread.c
+++ b/kernel/application/syscalls/yield_thread.c
@@ -33,5 +33,5 @@
 #include <kernel/domain/entities/thread.h>
 
 void yield_thread(void) {
-    yield_current_thread();
+    thread_yield_current();
 }

--- a/kernel/domain/entities/descriptor.c
+++ b/kernel/domain/entities/descriptor.c
@@ -111,11 +111,11 @@ static int descriptor_access_object_locked(
 
     if(object_is_destroyed(object)) {
         set_state(desc, DESC_STATE_DESTROYED);
-        close_object(object, desc);
+        object_close(object, desc);
         return -JINUE_EIO;
     }
 
-    add_ref_to_object(desc->object);
+    object_add_ref(desc->object);
     *pout = *desc;
 
     return 0;
@@ -179,7 +179,7 @@ int descriptor_access_object(
  * @param desc descriptor
  */
 void descriptor_unreference_object(descriptor_t *desc) {
-    sub_ref_to_object(desc->object);
+    object_sub_ref(desc->object);
 }
 
 /**
@@ -273,7 +273,7 @@ void descriptor_open(process_t *process, int fd, const descriptor_t *in) {
 
     spin_unlock(&process->descriptors_lock);
 
-    open_object(in->object, in);
+    object_open(in->object, in);
 }
 
 /**
@@ -308,7 +308,7 @@ int descriptor_close(process_t *process, int fd) {
     spin_unlock(&process->descriptors_lock);
 
     if(descriptor_is_open(&copy)) {
-        close_object(copy.object, &copy);
+        object_close(copy.object, &copy);
     }
 
     return 0;

--- a/kernel/domain/entities/descriptor.c
+++ b/kernel/domain/entities/descriptor.c
@@ -47,7 +47,7 @@
  * 
  * @param desc descriptor
  */
-void clear_descriptor(descriptor_t *desc) {
+void descriptor_clear(descriptor_t *desc) {
     desc->flags     = DESC_STATE_FREE;
     desc->object    = NULL;
     desc->cookie    = 0;
@@ -63,7 +63,7 @@ void clear_descriptor(descriptor_t *desc) {
  * @param fd descriptor number (DESC_STATE_... constant)
  * @return object reference on success, NULL if out of bound
  */
-static descriptor_t *dereference_descriptor(process_t *process, int fd) {
+static descriptor_t *dereference(process_t *process, int fd) {
     if(fd < 0 || fd > JINUE_DESC_NUM) {
         return NULL;
     }
@@ -87,14 +87,14 @@ static void set_state(descriptor_t *desc, int state)  {
 }
 
 /**
- * Portion of dereference_object_descriptor() performed under lock
+ * Portion of descriptor_access_object() performed under lock
  * 
  * @param pout pointer to where to copy the descriptor (out)
  * @param process process for which the descriptor is looked up
  * @param desc referenced descriptor
  * @return zero on success, negated error number on error
  */
-static int dereference_object_descriptor_locked(
+static int descriptor_access_object_locked(
         descriptor_t    *pout,
         process_t       *process,
         descriptor_t    *desc) {
@@ -142,19 +142,19 @@ static int dereference_object_descriptor_locked(
  * 
  * The caller *must* decrement the referenced object reference call when it is
  * done with it to free the reference added by this call. This can be done by
- * calling unreference_descriptor_object() on the descriptor copy.
+ * calling descriptor_unreference_object() on the descriptor copy.
  * 
  * @param pout pointer to where to copy the descriptor (out)
  * @param process process in which the descriptor is looked up
  * @param fd descriptor number
  * @return zero on success, negated error number on error
  */
-int dereference_object_descriptor(
+int descriptor_access_object(
         descriptor_t    *pout,
         process_t       *process,
         int              fd) {
 
-    descriptor_t *desc = dereference_descriptor(process, fd);
+    descriptor_t *desc = dereference(process, fd);
 
     if(desc == NULL) {
         return -JINUE_EBADF;
@@ -162,7 +162,7 @@ int dereference_object_descriptor(
 
     spin_lock(&process->descriptors_lock);
 
-    int status = dereference_object_descriptor_locked(pout, process, desc);
+    int status = descriptor_access_object_locked(pout, process, desc);
     
     spin_unlock(&process->descriptors_lock);
 
@@ -173,12 +173,12 @@ int dereference_object_descriptor(
  * Unreference the object referenced by a descriptor
  * 
  * Must be called on the copy of the descriptor obtained by calling
- * dereference_object_descriptor() when the caller is done accessing the
+ * descriptor_access_object() when the caller is done accessing the
  * object.
  * 
  * @param desc descriptor
  */
-void unreference_descriptor_object(descriptor_t *desc) {
+void descriptor_unreference_object(descriptor_t *desc) {
     sub_ref_to_object(desc->object);
 }
 
@@ -188,8 +188,8 @@ void unreference_descriptor_object(descriptor_t *desc) {
  * This function ensures the descriptor is free. If it is, it sets it state to
  * reserve (DESC_STATE_RESERVED) to prevent concurrent attempts to assign it.
  * 
- * Once a descriptor is reserved, it must be set with open_descriptor(), or the
- * reservation must be released with free_reserved_descriptor() if rolling back
+ * Once a descriptor is reserved, it must be set with descriptor_open(), or the
+ * reservation must be released with descriptor_free_reservation() if rolling back
  * becomes necessary.
  * 
  * This two step process allows the caller to confirm the availability of the
@@ -202,8 +202,8 @@ void unreference_descriptor_object(descriptor_t *desc) {
  * @param fd descriptor number
  * @return zero on success, negated error number on error
  */
-int reserve_free_descriptor(process_t *process, int fd) {
-    descriptor_t *desc = dereference_descriptor(process, fd);
+int descriptor_reserve_unused(process_t *process, int fd) {
+    descriptor_t *desc = dereference(process, fd);
 
     if(desc == NULL) {
         return -JINUE_EBADF;
@@ -227,20 +227,20 @@ int reserve_free_descriptor(process_t *process, int fd) {
  * Free a reserved descriptor
  * 
  * This function must be called for a descriptor reserved with
- * reserve_free_descriptor() if the descriptor will not be set with
- * open_descriptor().
+ * descriptor_reserve_unused() if the descriptor will not be set with
+ * descriptor_open().
  * 
  * @param process process for which the descriptor is looked up
  * @param fd descriptor number
  */
-void free_reserved_descriptor(process_t *process, int fd) {
-    descriptor_t *desc = dereference_descriptor(process, fd);
+void descriptor_free_reservation(process_t *process, int fd) {
+    descriptor_t *desc = dereference(process, fd);
 
     spin_lock(&process->descriptors_lock);
 
     assert(descriptor_is_reserved(desc));
 
-    clear_descriptor(desc);
+    descriptor_clear(desc);
 
     spin_unlock(&process->descriptors_lock);
 }
@@ -252,16 +252,16 @@ void free_reserved_descriptor(process_t *process, int fd) {
  * cookie. The object's reference count is incremented to reflect the new
  * reference by the descriptor. The object's open op is also called.
  * 
- * The descriptor must have been reserved with reserve_free_descriptor() before
+ * The descriptor must have been reserved with descriptor_reserve_unused() before
  * calling this function. This function does not do error checking because this
- * will have been done by reserve_free_descriptor().
+ * will have been done by descriptor_reserve_unused().
  * 
  * @param process process in which the descriptor is opened
  * @param fd descriptor number
  * @param in data to set on the descriptor
  */
-void open_descriptor(process_t *process, int fd, const descriptor_t *in) {
-    descriptor_t *desc = dereference_descriptor(process, fd);
+void descriptor_open(process_t *process, int fd, const descriptor_t *in) {
+    descriptor_t *desc = dereference(process, fd);
 
     spin_lock(&process->descriptors_lock);
 
@@ -287,8 +287,8 @@ void open_descriptor(process_t *process, int fd, const descriptor_t *in) {
  * @param fd descriptor number
  * @return zero on success, negated error number on error
  */
-int close_descriptor(process_t *process, int fd) {
-    descriptor_t *desc = dereference_descriptor(process, fd);
+int descriptor_close(process_t *process, int fd) {
+    descriptor_t *desc = dereference(process, fd);
 
     if(desc == NULL) {
         return -JINUE_EBADF;
@@ -303,7 +303,7 @@ int close_descriptor(process_t *process, int fd) {
 
     const descriptor_t copy = *desc;
 
-    clear_descriptor(desc);
+    descriptor_clear(desc);
     
     spin_unlock(&process->descriptors_lock);
 
@@ -321,12 +321,12 @@ int close_descriptor(process_t *process, int fd) {
  * endpoint is returned. Otherwise, the function fails by returning NULL.
  * 
  * This function is typically called on a descriptor copy obtain by calling
- * dereference_object_descriptor().
+ * descriptor_access_object().
  * 
  * @param desc descriptor
  * @return IPC endpoint on success, NULL on failure
  */
-ipc_endpoint_t *get_endpoint_from_descriptor(descriptor_t *desc) {
+ipc_endpoint_t *descriptor_get_endpoint(descriptor_t *desc) {
     object_header_t *object = desc->object;
 
     if(object->type != object_type_ipc_endpoint) {
@@ -343,12 +343,12 @@ ipc_endpoint_t *get_endpoint_from_descriptor(descriptor_t *desc) {
  * is returned. Otherwise, the function fails by returning NULL.
  * 
  * This function is typically called on a descriptor copy obtain by calling
- * dereference_object_descriptor().
+ * descriptor_access_object().
  * 
  * @param desc descriptor
  * @return process on success, NULL on failure
  */
-process_t *get_process_from_descriptor(descriptor_t *desc) {
+process_t *descriptor_get_process(descriptor_t *desc) {
     object_header_t *object = desc->object;
 
     if(object->type != object_type_process) {
@@ -365,12 +365,12 @@ process_t *get_process_from_descriptor(descriptor_t *desc) {
  * is returned. Otherwise, the function fails by returning NULL.
  * 
  * This function is typically called on a descriptor copy obtain by calling
- * dereference_object_descriptor().
+ * descriptor_access_object().
  * 
  * @param desc descriptor
  * @return thread on success, NULL on failure
  */
-thread_t *get_thread_from_descriptor(descriptor_t *desc) {
+thread_t *descriptor_get_thread(descriptor_t *desc) {
     object_header_t *object = desc->object;
 
     if(object->type != object_type_thread) {

--- a/kernel/domain/entities/endpoint.c
+++ b/kernel/domain/entities/endpoint.c
@@ -41,25 +41,25 @@
 #include <kernel/utils/list.h>
 #include <stddef.h>
 
-static void cache_endpoint_ctor(void *buffer, size_t size);
+static void cache_ctor_op(void *buffer, size_t size);
 
-static void open_endpoint(object_header_t *object, const descriptor_t *desc);
+static void open_op(object_header_t *object, const descriptor_t *desc);
 
-static void close_endpoint(object_header_t *object, const descriptor_t *desc);
+static void close_op(object_header_t *object, const descriptor_t *desc);
 
-static void destroy_endpoint(object_header_t *object);
+static void destroy_op(object_header_t *object);
 
-static void free_endpoint(object_header_t *object);
+static void free_op(object_header_t *object);
 
 static const object_type_t object_type = {
     .all_permissions    = JINUE_PERM_SEND | JINUE_PERM_RECEIVE,
     .name               = "ipc_endpoint",
     .size               = sizeof(ipc_endpoint_t),
-    .open               = open_endpoint,
-    .close              = close_endpoint,
-    .destroy            = destroy_endpoint,
-    .free               = free_endpoint,
-    .cache_ctor         = cache_endpoint_ctor,
+    .open               = open_op,
+    .close              = close_op,
+    .destroy            = destroy_op,
+    .free               = free_op,
+    .cache_ctor         = cache_ctor_op,
     .cache_dtor         = NULL
 };
 
@@ -77,7 +77,7 @@ static slab_cache_t ipc_endpoint_cache;
  * @param buffer IPC endpoint object being constructed
  * @param size size in bytes of the IPC endpoint object (ignored)
  */
-static void cache_endpoint_ctor(void *buffer, size_t size) {
+static void cache_ctor_op(void *buffer, size_t size) {
     ipc_endpoint_t *endpoint = buffer;
     
     init_object_header(&endpoint->header, object_type_ipc_endpoint);
@@ -115,7 +115,7 @@ static int sub_receiver(ipc_endpoint_t *endpoint) {
  * @param object the endpoint object
  * @param desc the new descriptor
  */
-static void open_endpoint(object_header_t *object, const descriptor_t *desc) {
+static void open_op(object_header_t *object, const descriptor_t *desc) {
     if(descriptor_has_permissions(desc, JINUE_PERM_RECEIVE)) {
         ipc_endpoint_t *endpoint = (ipc_endpoint_t *)object;
         add_receiver(endpoint);
@@ -132,7 +132,7 @@ static void open_endpoint(object_header_t *object, const descriptor_t *desc) {
  * @param object the endpoint object
  * @param desc the descriptor being closed
  */
-static void close_endpoint(object_header_t *object, const descriptor_t *desc) {
+static void close_op(object_header_t *object, const descriptor_t *desc) {
     if(descriptor_has_permissions(desc, JINUE_PERM_RECEIVE)) {
         ipc_endpoint_t *endpoint = (ipc_endpoint_t *)object;
         int receivers = sub_receiver(endpoint);
@@ -155,7 +155,7 @@ void initialize_endpoint_cache(void) {
  *
  * @return endpoint on success, NULL on allocation failure
  */
-ipc_endpoint_t *construct_endpoint(void) {
+ipc_endpoint_t *endpoint_new(void) {
     return slab_cache_alloc(&ipc_endpoint_cache);
 }
 
@@ -166,7 +166,7 @@ ipc_endpoint_t *construct_endpoint(void) {
  *
  * @param object the endpoint object
  */
-static void destroy_endpoint(object_header_t *object) {
+static void destroy_op(object_header_t *object) {
     ipc_endpoint_t *endpoint = (ipc_endpoint_t *)object;
 
     while(true) {
@@ -198,6 +198,6 @@ static void destroy_endpoint(object_header_t *object) {
  *
  * @param object the endpoint object
  */
-static void free_endpoint(object_header_t *object) {
+static void free_op(object_header_t *object) {
     slab_cache_free(object);
 }

--- a/kernel/domain/entities/endpoint.c
+++ b/kernel/domain/entities/endpoint.c
@@ -80,7 +80,7 @@ static slab_cache_t ipc_endpoint_cache;
 static void cache_ctor_op(void *buffer, size_t size) {
     ipc_endpoint_t *endpoint = buffer;
     
-    init_object_header(&endpoint->header, object_type_ipc_endpoint);
+    object_init_header(&endpoint->header, object_type_ipc_endpoint);
     init_list(&endpoint->send_list);
     init_list(&endpoint->recv_list);
     init_spinlock(&endpoint->lock);
@@ -138,7 +138,7 @@ static void close_op(object_header_t *object, const descriptor_t *desc) {
         int receivers = sub_receiver(endpoint);
 
         if(receivers < 1) {
-            destroy_object(object);
+            object_destroy(object);
         }
     }
 }

--- a/kernel/domain/entities/process.c
+++ b/kernel/domain/entities/process.c
@@ -82,7 +82,7 @@ static slab_cache_t process_cache;
  */
 static void cache_process_ctor(void *buffer, size_t ignore) {
     process_t *process = buffer;
-    init_object_header(&process->header, object_type_process);
+    object_init_header(&process->header, object_type_process);
 }
 
 /**
@@ -133,7 +133,7 @@ static void close_descriptors(process_t *process) {
         descriptor_t *desc = &process->descriptors[idx];
 
         if(descriptor_is_open(desc)) {
-            close_object(desc->object, desc);
+            object_close(desc->object, desc);
         }
     }
 }
@@ -194,7 +194,7 @@ process_t *get_current_process(void) {
  */
 void add_running_thread_to_process(process_t *process) {
     add_atomic(&process->running_threads_count, 1);
-    add_ref_to_object(&process->header);
+    object_add_ref(&process->header);
 }
 
 /**
@@ -214,8 +214,8 @@ void remove_running_thread_from_process(process_t *process) {
      * reference count alone is not enough because the process might have
      * descriptors that reference itself. */
     if(running_count < 1) {
-        destroy_object(&process->header);
+        object_destroy(&process->header);
     }
     
-    sub_ref_to_object(&process->header);
+    object_sub_ref(&process->header);
 }

--- a/kernel/domain/entities/process.c
+++ b/kernel/domain/entities/process.c
@@ -99,7 +99,7 @@ void initialize_process_cache(void) {
  */
 static void initialize_descriptors(process_t *process) {
     for(int idx = 0; idx < JINUE_DESC_NUM; ++idx) {
-        clear_descriptor(&process->descriptors[idx]);
+        descriptor_clear(&process->descriptors[idx]);
     }
 }
 

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -183,7 +183,7 @@ void ready_thread(thread_t *thread) {
  *
  */
 static void thread_is_starting(thread_t *thread) {
-    add_running_thread_to_process(thread->process);
+    process_add_running_thread(thread->process);
     
     /* Add a reference on the thread while it is running so it is allowed to
      * run to completion even if all descriptors that reference it get closed. */
@@ -204,7 +204,7 @@ static void thread_is_starting(thread_t *thread) {
  *
  */
 void run_first_thread(thread_t *thread) {
-    switch_to_process(thread->process);
+    process_switch_to(thread->process);
 
     thread_is_starting(thread);
 
@@ -301,13 +301,13 @@ void terminate_current_thread(void) {
     to->state       = THREAD_STATE_RUNNING;
     
     if(current->process != to->process) {
-        switch_to_process(to->process);
+        process_switch_to(to->process);
     }
 
     /* This must be done after switching process since it will destroy the process
      * if the current thread is the last one. We don't want to destroy the address
      * space we are still running in... */
-    remove_running_thread_from_process(current->process);
+    process_remove_running_thread(current->process);
 
     /* This function takes care of safely decrementing the reference count on
      * the thread after having switched to the other one. We cannot just do it
@@ -330,7 +330,7 @@ void switch_to(thread_t *to) {
     to->state           = THREAD_STATE_RUNNING;
 
     if(current->process != to->process) {
-        switch_to_process(to->process);
+        process_switch_to(to->process);
     }
 
     spin_lock(&ready_queue.lock);
@@ -352,7 +352,7 @@ void switch_to_and_block(thread_t *to) {
     to->state           = THREAD_STATE_RUNNING;
 
     if(current->process != to->process) {
-        switch_to_process(to->process);
+        process_switch_to(to->process);
     }
 
     machine_switch_thread(current, to);
@@ -381,7 +381,7 @@ void block_and_unlock(spinlock_t *lock) {
     to->state           = THREAD_STATE_RUNNING;
 
     if(current->process != to->process) {
-        switch_to_process(to->process);
+        process_switch_to(to->process);
     }
 
     machine_switch_thread_and_unlock(current, to, lock);
@@ -404,7 +404,7 @@ void yield_current_thread(void) {
     to->state = THREAD_STATE_RUNNING;
 
     if(current->process != to->process) {
-        switch_to_process(to->process);
+        process_switch_to(to->process);
     }
 
     spin_lock(&ready_queue.lock);

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -41,7 +41,7 @@
 #include <kernel/machine/tls.h>
 #include <kernel/utils/list.h>
 
-static void free_thread(object_header_t *object);
+static void free_op(object_header_t *object);
 
 static const object_type_t object_type = {
     .all_permissions    = JINUE_PERM_START | JINUE_PERM_AWAIT,
@@ -50,7 +50,7 @@ static const object_type_t object_type = {
     .open               = NULL,
     .close              = NULL,
     .destroy            = NULL,
-    .free               = free_thread,
+    .free               = free_op,
     .cache_ctor         = NULL,
     .cache_dtor         = NULL
 };
@@ -73,15 +73,15 @@ static struct {
  * The in-kernel thread implementation separates thread creation and thread
  * startup, which allows an application to keep kernel thread objects around in
  * a thread pool and reuse them as application threads exit and new ones start.
- * This function constructs a thread but does not start it. run_thread() (or
- * run_first_thread()) does that on an already constructed thread that has
- * been prepared for a first or new run with prepare_thread().
+ * This function constructs a thread but does not start it. thread_run() (or
+ * thread_run_first()) does that on an already constructed thread that has
+ * been prepared for a first or new run with thread_prepare().
  * 
  * @param process process in which to create the new thread
  * @return thread on success, NULL on memory allocation error
  *
  */
-thread_t *construct_thread(process_t *process) {
+thread_t *thread_new(process_t *process) {
     thread_t *thread = machine_alloc_thread();
 
     if(thread == NULL) {
@@ -110,7 +110,7 @@ thread_t *construct_thread(process_t *process) {
  * @param object object header of thread object
  *
  */
-static void free_thread(object_header_t *object) {
+static void free_op(object_header_t *object) {
     thread_t *thread = (thread_t *)object;
     machine_free_thread(thread);
 }
@@ -123,16 +123,16 @@ static void free_thread(object_header_t *object) {
  * point.
  * 
  * This function is separate from the thread constructor to allow a thread
- * to be reused by the application. (See construct_thread())
+ * to be reused by the application. (See thread_new())
  * 
  * Once a thread has been prepared by calling this function, it can be run
- * by calling run_thread() (or run_first_thread()).
+ * by calling thread_run() (or thread_run_first()).
  * 
  * @param thread the thread
  * @param params initialization parameters
  *
  */
-void prepare_thread(thread_t *thread, const thread_params_t *params) {
+void thread_prepare(thread_t *thread, const thread_params_t *params) {
     thread->sender  = NULL;
     
     spin_lock(&thread->await_lock);
@@ -148,14 +148,14 @@ void prepare_thread(thread_t *thread, const thread_params_t *params) {
 /**
  * Add a thread to the ready queue (without locking)
  * 
- * This funtion contains the business logic for ready_thread() without the
- * locking. Some functions beside ready_thread() that need to block and then
+ * This funtion contains the business logic for thread_ready() without the
+ * locking. Some functions beside thread_ready() that need to block and then
  * unlock call it, hence why it is a separate function.
  * 
  * @param thread the thread
  *
  */
-static void ready_thread_locked(thread_t *thread) {
+static void thread_ready_locked(thread_t *thread) {
     thread->state = THREAD_STATE_READY;
 
     /* add thread to the tail of the ready list to give other threads a chance to run */
@@ -168,10 +168,10 @@ static void ready_thread_locked(thread_t *thread) {
  * @param thread the thread
  *
  */
-void ready_thread(thread_t *thread) {
+void thread_ready(thread_t *thread) {
     spin_lock(&ready_queue.lock);
 
-    ready_thread_locked(thread);
+    thread_ready_locked(thread);
 
     spin_unlock(&ready_queue.lock);
 }
@@ -203,7 +203,7 @@ static void thread_is_starting(thread_t *thread) {
  * @param thread the thread to run
  *
  */
-void run_first_thread(thread_t *thread) {
+void thread_run_first(thread_t *thread) {
     process_switch_to(thread->process);
 
     thread_is_starting(thread);
@@ -215,15 +215,15 @@ void run_first_thread(thread_t *thread) {
  * Run a thread
  * 
  * Before this function is called, the thread must have been prepared with
- * prepare_thread().
+ * thread_prepare().
  * 
  * @param thread the thread to run
  *
  */
-void run_thread(thread_t *thread) {
+void thread_run(thread_t *thread) {
     thread_is_starting(thread);
 
-    ready_thread(thread);
+    thread_ready(thread);
 }
 
 /**
@@ -275,9 +275,9 @@ static thread_t *reschedule(bool current_can_run) {
  * 
  * The thread is destroyed and freed only if there are no more references to it
  * (i.e. no descriptors referencing it). Otherwise, it remains available to be
- * reused by calling prepare_thread() and then run_thread() again.
+ * reused by calling thread_prepare() and then thread_run() again.
  */
-void terminate_current_thread(void) {
+void thread_terminate_current(void) {
     thread_t *current = get_current_thread();
 
     spin_lock(&current->await_lock);
@@ -287,7 +287,7 @@ void terminate_current_thread(void) {
     current->state = THREAD_STATE_ZOMBIE;
 
     if(current->awaiter != NULL) {
-        ready_thread(current->awaiter);
+        thread_ready(current->awaiter);
     }
 
     spin_unlock(&current->await_lock);
@@ -324,7 +324,7 @@ void terminate_current_thread(void) {
  * @param to thread to switch to
  *
  */
-void switch_to(thread_t *to) {
+void thread_switch_to(thread_t *to) {
     thread_t *current   = get_current_thread();
 
     to->state           = THREAD_STATE_RUNNING;
@@ -335,7 +335,7 @@ void switch_to(thread_t *to) {
 
     spin_lock(&ready_queue.lock);
 
-    ready_thread_locked(current);
+    thread_ready_locked(current);
 
     machine_switch_thread_and_unlock(current, to, &ready_queue.lock);
 }
@@ -346,7 +346,7 @@ void switch_to(thread_t *to) {
  * @param to thread to switch to
  *
  */
-void switch_to_and_block(thread_t *to) {
+void thread_switch_to_and_block(thread_t *to) {
     thread_t *current   = get_current_thread();
     current->state      = THREAD_STATE_BLOCKED;
     to->state           = THREAD_STATE_RUNNING;
@@ -373,7 +373,7 @@ void switch_to_and_block(thread_t *to) {
  * @param lock the lock to unlock after switching thread
  *
  */
-void block_and_unlock(spinlock_t *lock) {
+void thread_block_current_and_unlock(spinlock_t *lock) {
     thread_t *current   = get_current_thread();
     current->state      = THREAD_STATE_BLOCKED;
 
@@ -393,7 +393,7 @@ void block_and_unlock(spinlock_t *lock) {
  * The current thread is added at the tail of the ready queue. It continues
  * running if no other thread is ready to run.
  */
-void yield_current_thread(void) {
+void thread_yield_current(void) {
     thread_t *current   = get_current_thread();
     thread_t *to        = reschedule(true);
 
@@ -409,7 +409,7 @@ void yield_current_thread(void) {
 
     spin_lock(&ready_queue.lock);
 
-    ready_thread_locked(current);
+    thread_ready_locked(current);
 
     machine_switch_thread_and_unlock(current, to, &ready_queue.lock);
 }
@@ -422,7 +422,7 @@ void yield_current_thread(void) {
  * @param size size of thread-local storage
  *
  */
-void set_thread_local_storage(thread_t *thread, addr_t addr, size_t size) {
+void thread_set_local_storage(thread_t *thread, addr_t addr, size_t size) {
     thread->local_storage_addr = addr;
     thread->local_storage_size = size;
 

--- a/kernel/domain/entities/thread.c
+++ b/kernel/domain/entities/thread.c
@@ -88,7 +88,7 @@ thread_t *construct_thread(process_t *process) {
         return NULL;
     }
 
-    init_object_header(&thread->header, object_type_thread);
+    object_init_header(&thread->header, object_type_thread);
 
     init_spinlock(&thread->await_lock);
 
@@ -187,7 +187,7 @@ static void thread_is_starting(thread_t *thread) {
     
     /* Add a reference on the thread while it is running so it is allowed to
      * run to completion even if all descriptors that reference it get closed. */
-    add_ref_to_object(&thread->header);
+    object_add_ref(&thread->header);
 
     thread->state = THREAD_STATE_RUNNING;
 }

--- a/kernel/domain/services/exec.c
+++ b/kernel/domain/services/exec.c
@@ -101,7 +101,7 @@ void exec(
     thread_params_t thread_params;
     machine_load_exec(&thread_params, process, exec_file, argv0, cmdline);
 
-    prepare_thread(thread, &thread_params);
+    thread_prepare(thread, &thread_params);
 
     initialize_descriptors(process, thread);
 }

--- a/kernel/domain/services/exec.c
+++ b/kernel/domain/services/exec.c
@@ -46,7 +46,7 @@
  * @param object object the descriptor will reference
  */
 static void set_descriptor(process_t *process, int fd, object_header_t *object) {
-    int status = reserve_free_descriptor(process, fd);
+    int status = descriptor_reserve_unused(process, fd);
 
     if(status < 0) {
         panic("Could not set up predefined descriptor for user space loader");
@@ -57,7 +57,7 @@ static void set_descriptor(process_t *process, int fd, object_header_t *object) 
     desc.flags  = object->type->all_permissions;
     desc.cookie = 0;
 
-    open_descriptor(process, fd, &desc);
+    descriptor_open(process, fd, &desc);
 }
 
 /**

--- a/kernel/domain/services/ipc.c
+++ b/kernel/domain/services/ipc.c
@@ -241,14 +241,14 @@ int send_message(
     if(receiver == NULL) {
         /* No thread is waiting to receive this message, so we must wait on the sender list. */
         list_enqueue(&endpoint->send_list, &sender->thread_list);
-        block_and_unlock(&endpoint->lock);
+        thread_block_current_and_unlock(&endpoint->lock);
     }
     else {
         spin_unlock(&endpoint->lock);
         receiver->sender = sender;
 
         /* switch to receiver thread, which will resume inside syscall_receive() */
-        switch_to_and_block(receiver);
+        thread_switch_to_and_block(receiver);
     }
 
     if(sender->message_errno == JINUE_EPROTO) {
@@ -307,7 +307,7 @@ int receive_message(ipc_endpoint_t *endpoint, thread_t *receiver, jinue_message_
         if(sender == NULL) {
             /* No thread is waiting to send a message, so we must wait on the receive list. */
             list_enqueue(&endpoint->recv_list, &receiver->thread_list);
-            block_and_unlock(&endpoint->lock);
+            thread_block_current_and_unlock(&endpoint->lock);
             
             /* set by sending thread */
             sender = receiver->sender;
@@ -327,7 +327,7 @@ int receive_message(ipc_endpoint_t *endpoint, thread_t *receiver, jinue_message_
             sender->message_errno   = JINUE_E2BIG;
             receiver->sender        = NULL;
             
-            ready_thread(sender);
+            thread_ready(sender);
             continue;
         }
 
@@ -382,7 +382,7 @@ int reply_to_message(thread_t *replier, const jinue_message_t *message) {
     replier->sender = NULL;
     
     /* switch back to sender thread to return from call immediately */
-    switch_to(replyto);
+    thread_switch_to(replyto);
 
     return 0;
 }
@@ -410,7 +410,7 @@ int reply_error_to_message(thread_t *replier, uintptr_t errcode) {
     replier->sender                 = NULL;
     
     /* switch back to sender thread to return from call immediately */
-    switch_to(replyto);
+    thread_switch_to(replyto);
 
     return 0;
 }
@@ -431,5 +431,5 @@ int reply_error_to_message(thread_t *replier, uintptr_t errcode) {
  */
 void abort_message(thread_t *thread) {
     thread->message_errno = JINUE_EIO;
-    ready_thread(thread);
+    thread_ready(thread);
 }

--- a/kernel/infrastructure/i686/thread.asm
+++ b/kernel/infrastructure/i686/thread.asm
@@ -32,7 +32,7 @@
 
     bits 32
     
-    extern sub_ref_to_object
+    extern object_sub_ref
 
 ; ------------------------------------------------------------------------------
 ; FUNCTION: switch_thread_stack

--- a/kernel/infrastructure/i686/thread.c
+++ b/kernel/infrastructure/i686/thread.c
@@ -166,7 +166,7 @@ void machine_switch_thread(thread_t *from, thread_t *to) {
 
 static void unref_cleanup_handler(void *arg) {
     thread_t *thread = arg;
-    sub_ref_to_object(&thread->header);
+    object_sub_ref(&thread->header);
 }
 
 void machine_switch_and_unref_thread(thread_t *from, thread_t *to) {


### PR DESCRIPTION
Rename entity functions so function name starts with the entity name. This prevents conflicts and ambiguity with application layer functions.