### PR TITLE
Rename handlers

### DIFF
--- a/include/kernel/interface/i686/interrupts.h
+++ b/include/kernel/interface/i686/interrupts.h
@@ -33,15 +33,12 @@
 #define JINUE_KERNEL_INTERFACE_I686_INTERRUPT_H
 
 #include <kernel/infrastructure/i686/types.h>
-#include <kernel/interface/i686/asm/irq.h>
 #include <kernel/interface/i686/types.h>
-#include <stdint.h>
 
 
 /* defined in trap.asm */
 extern seg_descriptor_t idt[];
 
-void dispatch_interrupt(trapframe_t *trapframe);
+void handle_interrupt(trapframe_t *trapframe);
 
 #endif
-

--- a/include/kernel/interface/syscalls.h
+++ b/include/kernel/interface/syscalls.h
@@ -34,6 +34,6 @@
 
 #include <jinue/shared/types.h>
 
-void dispatch_syscall(jinue_syscall_args_t *args);
+void handle_syscall(jinue_syscall_args_t *args);
 
 #endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -116,7 +116,7 @@ sources.kernel.c = \
 	infrastructure/elf.c \
 	interface/i686/auxv.c \
 	interface/i686/bootinfo.c \
-	interface/i686/interrupt.c \
+	interface/i686/interrupts.c \
 	interface/syscalls.c
 
 sources.kernel.nasm = \

--- a/kernel/infrastructure/i686/init.c
+++ b/kernel/infrastructure/i686/init.c
@@ -49,8 +49,9 @@
 #include <kernel/infrastructure/i686/memory.h>
 #include <kernel/infrastructure/i686/percpu.h>
 #include <kernel/infrastructure/elf.h>
+#include <kernel/interface/i686/asm/irq.h>
 #include <kernel/interface/i686/boot.h>
-#include <kernel/interface/i686/interrupt.h>
+#include <kernel/interface/i686/interrupts.h>
 #include <kernel/interface/i686/trap.h>
 #include <kernel/interface/syscalls.h>
 #include <kernel/machine/asm/machine.h>

--- a/kernel/interface/i686/interrupts.c
+++ b/kernel/interface/i686/interrupts.c
@@ -34,13 +34,14 @@
 #include <kernel/infrastructure/i686/drivers/pic8259.h>
 #include <kernel/infrastructure/i686/isa/io.h>
 #include <kernel/infrastructure/i686/isa/regs.h>
-#include <kernel/interface/i686/interrupt.h>
+#include <kernel/interface/i686/asm/irq.h>
+#include <kernel/interface/i686/interrupts.h>
 #include <kernel/interface/syscalls.h>
 #include <kernel/machine/asm/machine.h>
 #include <inttypes.h>
 
 
-void dispatch_interrupt(trapframe_t *trapframe) {
+void handle_interrupt(trapframe_t *trapframe) {
     unsigned int    ivt         = trapframe->ivt;
     uintptr_t       eip         = trapframe->eip;
     uint32_t        errcode     = trapframe->errcode;
@@ -60,7 +61,7 @@ void dispatch_interrupt(trapframe_t *trapframe) {
     
     if(ivt == JINUE_I686_SYSCALL_IRQ) {
     	/* interrupt-based system call implementation */
-        dispatch_syscall((jinue_syscall_args_t *)&trapframe->msg_arg0);
+        handle_syscall((jinue_syscall_args_t *)&trapframe->msg_arg0);
     }
     else if(ivt >= IDT_PIC8259_BASE && ivt < IDT_PIC8259_BASE + PIC8259_IRQ_COUNT) {
     	int irq = ivt - IDT_PIC8259_BASE;

--- a/kernel/interface/i686/trap.asm
+++ b/kernel/interface/i686/trap.asm
@@ -33,8 +33,8 @@
 
     bits 32
 
-    extern dispatch_interrupt
-    extern dispatch_syscall
+    extern handle_interrupt
+    extern handle_syscall
 
 ; ------------------------------------------------------------------------------
 ; FUNCTION: interrupt_entry
@@ -128,11 +128,11 @@ interrupt_entry:
     mov eax, SEG_SELECTOR(GDT_PER_CPU_DATA, RPL_KERNEL)
     mov gs, ax
     
-    ; set dispatch_interrupt() function argument
+    ; set handle_interrupt() function argument
     push esp            ; First argument:  trapframe
     
     ; call interrupt dispatching function
-    call dispatch_interrupt
+    call handle_interrupt
     
     ; remove argument(s) from stack
     add esp, 4
@@ -208,16 +208,16 @@ fast_intel_entry:
     mov eax, SEG_SELECTOR(GDT_PER_CPU_DATA, RPL_KERNEL)
     mov gs, ax
     
-    ; set dispatch_syscall() function argument
+    ; set handle_syscall() function argument
     ;
-    ; The message arguments, a ponter to which dispatch_syscall() takes
+    ; The message arguments, a ponter to which handle_syscall() takes
     ; as argument are at the beginning of the trap frame, so we can just
     ; pass the address of the trap frame.
     push esp                ; First argument: message arguments
     
-    call dispatch_syscall
+    call handle_syscall
     
-    ; cleanup dispatch_syscall() argument
+    ; cleanup handle_syscall() argument
     add esp, 4
     
     pop eax                 ; 0
@@ -299,16 +299,16 @@ fast_amd_entry:
     mov ds, cx
     mov es, cx
     
-    ; set dispatch_syscall() function argument
+    ; set handle_syscall() function argument
     ;
-    ; The message arguments, a ponter to which dispatch_syscall() takes
+    ; The message arguments, a ponter to which handle_syscall() takes
     ; as argument are at the beginning of the trap frame, so we can just
     ; pass the address of the trap frame.
     push esp                ; First argument: message arguments
     
-    call dispatch_syscall
+    call handle_syscall
     
-    ; cleanup dispatch_syscall() argument
+    ; cleanup handle_syscall() argument
     add esp, 4
     
     pop eax                 ; 0

--- a/kernel/interface/syscalls.c
+++ b/kernel/interface/syscalls.c
@@ -562,7 +562,7 @@ static void sys_reply_error(jinue_syscall_args_t *args) {
  *
  * @param trapframe trap frame for current system call
  */
-void dispatch_syscall(jinue_syscall_args_t *args) {
+void handle_syscall(jinue_syscall_args_t *args) {
     intptr_t function = args->arg0;
     
     if(function < 0) {


### PR DESCRIPTION
* Rename `dispatch_syscall()` to `handle_syscall()`.
* Rename `dispatch_interrupt()` to `handle_interrupt()`.
* Rename interrupt.c/.h to interrupts.c/.h.
* Cleanup `#include`s