### PR TITLE
Fix build

### DIFF
--- a/include/kernel/infrastructure/i686/drivers/pic8259.h
+++ b/include/kernel/infrastructure/i686/drivers/pic8259.h
@@ -35,7 +35,7 @@
 #include <kernel/infrastructure/i686/drivers/asm/pic8259.h>
 #include <stdbool.h>
 
-void pic8259_init();
+void pic8259_init(void);
 
 void pic8259_mask(int irq);
 

--- a/kernel/infrastructure/i686/drivers/pic8259.c
+++ b/kernel/infrastructure/i686/drivers/pic8259.c
@@ -110,7 +110,7 @@ static uint8_t read_isr(pic8259_t *pic8259) {
     return inb(pic8259->io_base + 0);
 }
 
-void pic8259_init() {
+void pic8259_init(void) {
     initialize(&main_pic8259);
     initialize(&proxied_pic8259);
 }

--- a/userspace/testapp/tests/ipc.c
+++ b/userspace/testapp/tests/ipc.c
@@ -48,7 +48,6 @@ static void ipc_test_run_client(void) {
     char reply2[5];
     char reply1[6];
     char reply3[40];
-    int errno;
 
     const char hello[] = "Hello ";
     const char world[] = "World!";


### PR DESCRIPTION
Fix build errors:

* Fix missing `void` in `pic8259_init()` prototype which causes build to fail.
* Remove leftover declaration for `errno`.