### PR TITLE
Eliminate the separate types for user space and kernel addresses

### DIFF
--- a/include/kernel/domain/alloc/page_alloc.h
+++ b/include/kernel/domain/alloc/page_alloc.h
@@ -34,7 +34,7 @@
 
 #include <kernel/types.h>
 
-#define PFNULL ((kern_paddr_t)-1)
+#define PFNULL ((paddr_t)-1)
 
 void *page_alloc(void);
 
@@ -42,9 +42,9 @@ void page_free(void *page);
 
 unsigned int get_page_count(void);
 
-bool add_page_frame(kern_paddr_t paddr);
+bool add_page_frame(paddr_t paddr);
 
-kern_paddr_t remove_page_frame(void);
+paddr_t remove_page_frame(void);
 
 void clear_page(void *page);
 

--- a/include/kernel/domain/services/mman.h
+++ b/include/kernel/domain/services/mman.h
@@ -35,7 +35,7 @@
 #include <kernel/machine/types.h>
 #include <stddef.h>
 
-void *map_in_kernel(kern_paddr_t paddr, size_t size, int prot);
+void *map_in_kernel(paddr_t paddr, size_t size, int prot);
 
 void resize_map_in_kernel(size_t size);
 

--- a/include/kernel/infrastructure/acpi/acpi.h
+++ b/include/kernel/infrastructure/acpi/acpi.h
@@ -35,6 +35,7 @@
 #include <kernel/machine/types.h>
 #include <kernel/infrastructure/acpi/tables.h>
 #include <kernel/infrastructure/acpi/types.h>
+#include <kernel/machine/types.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -42,7 +43,7 @@ bool verify_acpi_checksum(const void *buffer, size_t buflen);
 
 bool validate_acpi_rsdp(const acpi_rsdp_t *rsdp);
 
-void map_acpi_tables(kern_paddr_t rsdp_paddr, const acpi_table_def_t *table_defs);
+void map_acpi_tables(paddr_t rsdp_paddr, const acpi_table_def_t *table_defs);
 
 void report_acpi_tables(const acpi_table_def_t *table_defs);
 

--- a/include/kernel/infrastructure/i686/exports/types.h
+++ b/include/kernel/infrastructure/i686/exports/types.h
@@ -37,15 +37,10 @@
 /* This file contains the machine-specific definitions that need to be visible
  * outside the machine-specific parts of the code. */
 
-/** Physical memory address for use by the kernel */
-typedef uint32_t kern_paddr_t;
-
 /** Physical memory address */
 typedef uint64_t paddr_t;
 
-#define PRIxKPADDR PRIx32
-
-#define PRIxUPADDR PRIx64
+#define PRIxPADDR PRIx64
 
 /** incomplete structure declaration for a page table entry
  *

--- a/include/kernel/infrastructure/i686/exports/types.h
+++ b/include/kernel/infrastructure/i686/exports/types.h
@@ -40,8 +40,8 @@
 /** Physical memory address for use by the kernel */
 typedef uint32_t kern_paddr_t;
 
-/** Physical memory address for use by user space */
-typedef uint64_t user_paddr_t;
+/** Physical memory address */
+typedef uint64_t paddr_t;
 
 #define PRIxKPADDR PRIx32
 

--- a/include/kernel/infrastructure/i686/firmware/acpi.h
+++ b/include/kernel/infrastructure/i686/firmware/acpi.h
@@ -41,6 +41,6 @@ void init_acpi(void);
 
 void report_acpi(void);
 
-kern_paddr_t acpi_get_rsdp_paddr(void);
+uint32_t acpi_get_rsdp_paddr(void);
 
 #endif

--- a/include/kernel/infrastructure/i686/pmap/pmap.h
+++ b/include/kernel/infrastructure/i686/pmap/pmap.h
@@ -49,16 +49,16 @@
 #define VIRT_TO_PHYS_AT_1MB(x)      (((uintptr_t)(x)) - BOOT_OFFSET_FROM_1MB)
 
 /** convert pointer to physical address for kernel loaded at 0x100000 (1MB) */
-#define PTR_TO_PHYS_ADDR_AT_1MB(x)  ((kern_paddr_t)VIRT_TO_PHYS_AT_1MB(x))
+#define PTR_TO_PHYS_ADDR_AT_1MB(x)  ((paddr_t)VIRT_TO_PHYS_AT_1MB(x))
 
 /** convert physical to virtual address for kernel loaded at 0x1000000 (16MB) */
-#define PHYS_TO_VIRT_AT_16MB(x)      (((uintptr_t)(x)) + BOOT_OFFSET_FROM_16MB)
+#define PHYS_TO_VIRT_AT_16MB(x)     (((uintptr_t)(x)) + BOOT_OFFSET_FROM_16MB)
 
 /** convert virtual to physical address for kernel loaded at 0x1000000 (16MB) */
-#define VIRT_TO_PHYS_AT_16MB(x)      (((uintptr_t)(x)) - BOOT_OFFSET_FROM_16MB)
+#define VIRT_TO_PHYS_AT_16MB(x)     (((uintptr_t)(x)) - BOOT_OFFSET_FROM_16MB)
 
 /** convert pointer to physical address for kernel loaded at 0x1000000 (16MB) */
-#define PTR_TO_PHYS_ADDR_AT_16MB(x)  ((kern_paddr_t)VIRT_TO_PHYS_AT_16MB(x))
+#define PTR_TO_PHYS_ADDR_AT_16MB(x)  ((paddr_t)VIRT_TO_PHYS_AT_16MB(x))
 
 #define ADDR_4GB    UINT64_C(0x100000000)
 
@@ -77,19 +77,4 @@ void pmap_destroy_addr_space(addr_space_t *addr_space);
 
 void pmap_switch_addr_space(addr_space_t *addr_space);
 
-void pmap_map_kernel_page(void *vaddr, kern_paddr_t paddr, int flags);
-
-void pmap_unmap_kernel_page(void *addr);
-
-void pmap_unmap_userspace(addr_space_t *addr_space, void *addr);
-
-bool pmap_clone_range(
-        addr_space_t    *dest_addr_space,
-        addr_space_t    *src_addr_space,
-        addr_t           dest_addr,
-        addr_t           src_addr,
-        size_t           length,
-        int              prot);
-
 #endif
-

--- a/include/kernel/interface/i686/types.h
+++ b/include/kernel/interface/i686/types.h
@@ -51,7 +51,7 @@ typedef struct {
     void                    *image_start;
     void                    *image_top;
     uint32_t                 ramdisk_start;
-    size_t	                 ramdisk_size;
+    size_t                   ramdisk_size;
     const acpi_addr_range_t *acpi_addr_map;
     uint32_t                 addr_map_entries;
     void                    *cmdline;

--- a/include/kernel/interface/i686/types.h
+++ b/include/kernel/interface/i686/types.h
@@ -50,7 +50,7 @@ typedef struct {
     size_t                   loader_size;
     void                    *image_start;
     void                    *image_top;
-    kern_paddr_t             ramdisk_start;
+    uint32_t                 ramdisk_start;
     size_t	                 ramdisk_size;
     const acpi_addr_range_t *acpi_addr_map;
     uint32_t                 addr_map_entries;

--- a/include/kernel/machine/pmap.h
+++ b/include/kernel/machine/pmap.h
@@ -42,7 +42,7 @@ bool machine_map_userspace(
         process_t       *process,
         void            *vaddr,
         size_t           length,
-        user_paddr_t     paddr,
+        paddr_t          paddr,
         int              prot);
 
 bool machine_clone_userspace_mapping(

--- a/include/kernel/machine/pmap.h
+++ b/include/kernel/machine/pmap.h
@@ -34,7 +34,7 @@
 
 #include <kernel/types.h>
 
-void machine_map_kernel_page(void *vaddr, kern_paddr_t paddr, int prot);
+void machine_map_kernel_page(void *vaddr, paddr_t paddr, int prot);
 
 void machine_unmap_kernel_page(void *addr);
 
@@ -53,6 +53,6 @@ bool machine_clone_userspace_mapping(
         size_t       length,
         int          prot) ;
 
-kern_paddr_t machine_lookup_kernel_paddr(const void *addr);
+paddr_t machine_lookup_kernel_paddr(const void *addr);
 
 #endif

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -146,8 +146,8 @@ typedef struct {
 } exec_file_t;
 
 typedef struct {
-    kern_paddr_t    start;
-    size_t          size;
+    paddr_t start;
+    size_t  size;
 } kern_mem_block_t;
 
 typedef struct {

--- a/kernel/application/kmain.c
+++ b/kernel/application/kmain.c
@@ -75,7 +75,7 @@ void kmain(const char *cmdline) {
     machine_get_ramdisk(&ramdisk);
 
     info(
-        "Found RAM disk with size %zu bytes at address %#" PRIxKPADDR ".",
+        "Found RAM disk with size %zu bytes at address %#" PRIxPADDR ".",
         ramdisk.size,
         ramdisk.start
     );

--- a/kernel/domain/alloc/page_alloc.c
+++ b/kernel/domain/alloc/page_alloc.c
@@ -118,7 +118,7 @@ unsigned int get_page_count(void) {
  * @return true if the function succeeded
  *
  * */
-bool add_page_frame(kern_paddr_t paddr) {
+bool add_page_frame(paddr_t paddr) {
     void *page = vmalloc();
 
     if(page == NULL) {
@@ -149,7 +149,7 @@ bool add_page_frame(kern_paddr_t paddr) {
  * @return physical address of the freed page frame, or PFNULL if none is available
  *
  * */
-kern_paddr_t remove_page_frame(void) {
+paddr_t remove_page_frame(void) {
     void *page = page_alloc();
 
     if(page == NULL) {
@@ -161,7 +161,7 @@ kern_paddr_t remove_page_frame(void) {
      * for exploiting vulnerabilities. */
     clear_page(page);
 
-    kern_paddr_t paddr = machine_lookup_kernel_paddr(page);
+    paddr_t paddr = machine_lookup_kernel_paddr(page);
 
     machine_unmap_kernel_page(page);
 

--- a/kernel/domain/services/mman.c
+++ b/kernel/domain/services/mman.c
@@ -61,7 +61,7 @@ static struct {
  * @param size size of memory to map
  * @param prot mapping protection flags
  */
-void *map_in_kernel(kern_paddr_t paddr, size_t size, int prot) {
+void *map_in_kernel(paddr_t paddr, size_t size, int prot) {
     size_t offset = paddr % PAGE_SIZE;
     
     size += offset;
@@ -76,7 +76,7 @@ void *map_in_kernel(kern_paddr_t paddr, size_t size, int prot) {
     alloc_state.latest_prot     = prot;
 
     addr_t map_addr = start;
-    kern_paddr_t map_paddr = paddr - offset;
+    paddr_t map_paddr = paddr - offset;
 
     while(true) {
         machine_map_kernel_page(map_addr, map_paddr, prot);
@@ -114,10 +114,11 @@ void resize_map_in_kernel(size_t size) {
 
     /* Map additional pages if the mapping is grown. */
 
-    kern_paddr_t paddr = machine_lookup_kernel_paddr(start) + (new_end - old_end);
+    paddr_t paddr = machine_lookup_kernel_paddr(start) + (new_end - old_end);
 
     for(addr_t page_addr = old_end; page_addr < (addr_t)new_end; page_addr += PAGE_SIZE) {
         machine_map_kernel_page(page_addr, paddr, prot);
+        /* TODO recheck this */
         ++paddr;
     }
 

--- a/kernel/infrastructure/acpi/acpi.c
+++ b/kernel/infrastructure/acpi/acpi.c
@@ -106,7 +106,7 @@ static bool verify_table_signature(const acpi_table_header_t *header, const char
  * @return pointer to mapped RSDP on success, NULL on error
  *
  * */
-static const acpi_rsdp_t *map_rsdp(uint64_t paddr) {
+static const acpi_rsdp_t *map_rsdp(paddr_t paddr) {
     return map_in_kernel(paddr, sizeof(acpi_rsdp_t), JINUE_PROT_READ);
 }
 
@@ -142,7 +142,7 @@ static const void *map_table(const acpi_table_header_t *header) {
  * @return pointer to mapped header on success, NULL on error
  *
  * */
-static const acpi_table_header_t *map_header(kern_paddr_t paddr) {
+static const acpi_table_header_t *map_header(paddr_t paddr) {
     return map_in_kernel(paddr, sizeof(acpi_table_header_t), JINUE_PROT_READ);
 }
 
@@ -225,6 +225,7 @@ static void process_rsdt(const acpi_rsdt_t *rsdt, bool is_xsdt, const acpi_table
 
     for(int idx = 0; idx < entries; ++idx) {
         /* x86 is little endian */
+        /* TODO this part is not portable across architectures */
         uint64_t paddr = rsdt->entries[idx];
 
         if(is_xsdt) {
@@ -247,7 +248,7 @@ static void process_rsdt(const acpi_rsdt_t *rsdt, bool is_xsdt, const acpi_table
  * @param rsdp_paddr physical memory address of the RSDP
  * @param table_defs table definitions array terminated by a NULL signature
  */
-void map_acpi_tables(kern_paddr_t rsdp_paddr, const acpi_table_def_t *table_defs) {
+void map_acpi_tables(paddr_t rsdp_paddr, const acpi_table_def_t *table_defs) {
     const acpi_rsdp_t *rsdp = map_rsdp(rsdp_paddr);
 
     uint64_t rsdt_paddr;

--- a/kernel/infrastructure/elf.c
+++ b/kernel/infrastructure/elf.c
@@ -150,7 +150,7 @@ bool elf_check(Elf32_Ehdr *ehdr) {
 static void checked_map_userspace_page(
         process_t       *process,
         void            *vaddr,
-        user_paddr_t     paddr,
+        paddr_t          paddr,
         int              flags) {
 
     /* TODO check user space pointers

--- a/kernel/infrastructure/i686/boot_alloc.c
+++ b/kernel/infrastructure/i686/boot_alloc.c
@@ -47,7 +47,7 @@
  * This function sets up the allocator to allocate pages after the kernel loaded
  * at 0x100000 (1MB). Once the kernel has been moved to 0x1000000 (16MB), the
  * boot_alloc_reinit_at_16mb() function has to be called to start allocating pages
- * there.
+ * there instead.
  *
  * @param boot_alloc the allocator state initialized by this function
  * @param bootinfo boot information structure
@@ -58,7 +58,7 @@ void boot_alloc_init(boot_alloc_t *boot_alloc, const bootinfo_t *bootinfo) {
     boot_alloc->heap_ptr = bootinfo->boot_heap;
     /* TODO handle heap limit. */
 
-    boot_alloc->current_page        = (void *)PTR_TO_PHYS_ADDR_AT_1MB(bootinfo->boot_end);
+    boot_alloc->current_page        = (void *)VIRT_TO_PHYS_AT_1MB(bootinfo->boot_end);
     boot_alloc->page_limit          = (char *)MEMORY_ADDR_1MB + BOOT_SIZE_AT_1MB;
     boot_alloc->first_page_at_16mb  = (char *)bootinfo->page_table_1mb + 15 * MB;
 }

--- a/kernel/infrastructure/i686/firmware/acpi.c
+++ b/kernel/infrastructure/i686/firmware/acpi.c
@@ -161,6 +161,6 @@ void report_acpi(void) {
  *
  * @return physical address of RSDP if found, zero otherwise
  */
-kern_paddr_t acpi_get_rsdp_paddr(void) {
+uint32_t acpi_get_rsdp_paddr(void) {
     return rsdp_paddr;
 }

--- a/kernel/infrastructure/i686/pmap/pae.c
+++ b/kernel/infrastructure/i686/pmap/pae.c
@@ -375,10 +375,10 @@ bool pae_create_addr_space(addr_space_t *addr_space, pte_t *first_page_directory
     }
 
     /* Lookup the physical address of the page where the PDPT resides. */
-    kern_paddr_t pdpt_page_paddr = machine_lookup_kernel_paddr((addr_t)page_address_of(pdpt));
+    paddr_t pdpt_page_paddr = machine_lookup_kernel_paddr((addr_t)page_address_of(pdpt));
 
     /* physical address of PDPT */
-    kern_paddr_t pdpt_paddr = pdpt_page_paddr | page_offset_of(pdpt);
+    paddr_t pdpt_paddr = pdpt_page_paddr | page_offset_of(pdpt);
 
     addr_space->top_level.pdpt  = pdpt;
     addr_space->cr3             = pdpt_paddr;

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -209,7 +209,7 @@ void copy_ptes(pte_t *dest, const pte_t *src, int n) {
  * @param paddr physical address of page frame
  * @param flags flags
  */
-static void set_pte(pte_t *pte, user_paddr_t paddr, uint64_t flags) {
+static void set_pte(pte_t *pte, paddr_t paddr, uint64_t flags) {
     if(pgtable_format_pae) {
         pae_set_pte(pte, paddr, flags);
     }
@@ -256,7 +256,7 @@ void clear_ptes(pte_t *pte, int n) {
  * @param pte page table or page directory entry array
  * @return physical address
  */
-static user_paddr_t get_pte_paddr(const pte_t *pte) {
+static paddr_t get_pte_paddr(const pte_t *pte) {
     if(pgtable_format_pae) {
         return pae_get_pte_paddr(pte);
     }
@@ -743,7 +743,7 @@ static uint64_t map_page_access_flags(int prot) {
 static bool map_page(
         addr_space_t    *addr_space,
         void            *vaddr,
-        user_paddr_t     paddr,
+        paddr_t          paddr,
         uint64_t         flags) {
 
     /** ASSERTION: we assume vaddr is aligned on a page boundary */
@@ -799,7 +799,7 @@ void machine_map_kernel_page(void *vaddr, kern_paddr_t paddr, int prot) {
 static bool map_userspace_page(
         addr_space_t    *addr_space,
         void            *vaddr,
-        user_paddr_t     paddr,
+        paddr_t          paddr,
         int              prot) {
 
     assert(is_userspace_pointer(vaddr));
@@ -823,7 +823,7 @@ bool machine_map_userspace(
         process_t       *process,
         void            *vaddr,
         size_t           length,
-        user_paddr_t     paddr,
+        paddr_t          paddr,
         int              prot) {
 
     addr_t addr                 = vaddr;
@@ -917,7 +917,7 @@ bool machine_clone_userspace_mapping(
             unmap_page(dest_addr_space, dest_addr);
         }
         else {
-            user_paddr_t paddr = get_pte_paddr(src_pte);
+            paddr_t paddr = get_pte_paddr(src_pte);
 
             if(!map_userspace_page(dest_addr_space, dest_addr, paddr, prot)) {
                 return false;

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -778,8 +778,7 @@ static bool map_page(
  * @param paddr address of page frame
  * @param prot protections flags
  */
-void machine_map_kernel_page(void *vaddr, kern_paddr_t paddr, int prot) {
-    /* TODO the kern_paddr_t type prevents this function from supporting addresses above 4GB. */
+void machine_map_kernel_page(void *vaddr, paddr_t paddr, int prot) {
     assert(is_kernel_pointer(vaddr));
     map_page(NULL, vaddr, paddr, map_page_access_flags(prot) | X86_PTE_GLOBAL);
 }
@@ -937,12 +936,12 @@ bool machine_clone_userspace_mapping(
  * @param addr virtual address of kernel page
  * @return physical address of page frame
  */
-kern_paddr_t machine_lookup_kernel_paddr(const void *addr) {
+paddr_t machine_lookup_kernel_paddr(const void *addr) {
     assert( is_kernel_pointer(addr) );
 
     pte_t *pte = lookup_page_table_entry(NULL, addr, false, NULL);
 
     assert(pte != NULL && pte_is_present(pte));
 
-    return (kern_paddr_t)get_pte_paddr(pte);
+    return get_pte_paddr(pte);
 }


### PR DESCRIPTION
There are currently two types in the kernel for physical addresses:
* `kern_paddr_t` for addresses to memory used by the kernel.
* `user_paddr_t` for addresses to memory used by the kernel.

The original rationale was that the kernel only uses memory under the 4GB, so `kern_paddr_t` could be 32 bits instead of 64 bits. While this is true, the kernel might still need to map things above this mark like ACPI table.

This PR replaces both types with a single `paddr_t` type.