### PR TITLE
Refactor page table entry lookup

### DIFF
--- a/include/kernel/machine/pmap.h
+++ b/include/kernel/machine/pmap.h
@@ -34,13 +34,13 @@
 
 #include <kernel/types.h>
 
-void machine_map_kernel_page(void *vaddr, paddr_t paddr, int prot);
+void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot);
 
-void machine_unmap_kernel_page(void *addr);
+void machine_unmap_kernel(addr_t addr, size_t size);
 
 bool machine_map_userspace(
         process_t       *process,
-        void            *vaddr,
+        addr_t           addr,
         size_t           length,
         paddr_t          paddr,
         int              prot);

--- a/kernel/domain/alloc/page_alloc.c
+++ b/kernel/domain/alloc/page_alloc.c
@@ -125,7 +125,7 @@ bool add_page_frame(paddr_t paddr) {
         return false;
     }
 
-    machine_map_kernel_page(page, paddr, JINUE_PROT_READ | JINUE_PROT_WRITE);
+    machine_map_kernel(page, PAGE_SIZE, paddr, JINUE_PROT_READ | JINUE_PROT_WRITE);
 
     /* Since this page is coming from userspace, is is important to clear it:
      * 1) The page may contain sensitive information, which we don't want to
@@ -163,7 +163,7 @@ paddr_t remove_page_frame(void) {
 
     paddr_t paddr = machine_lookup_kernel_paddr(page);
 
-    machine_unmap_kernel_page(page);
+    machine_unmap_kernel(page, PAGE_SIZE);
 
     /* The page may be in the image region instead of the allocations region if
      * it was allocated during kernel initialization.

--- a/kernel/domain/services/mman.c
+++ b/kernel/domain/services/mman.c
@@ -65,12 +65,7 @@ static void expand_mapping(paddr_t paddr, addr_t new_end, int prot) {
         panic("No more space to map memory in kernel");
     }
 
-    /* Be careful about the possible address overflow here since the mapping
-     * area is at the very top of the address space. This is why we are using
-     * a condition on the offset rather than the address. */
-    for(int offset = 0; offset < size; offset += PAGE_SIZE) {
-        machine_map_kernel_page(old_end + offset, paddr + offset, prot);
-    }
+    machine_map_kernel(old_end, size, paddr, prot);
 
     alloc_state.addr            = new_end;
     alloc_state.size_remaining  -= size;
@@ -85,13 +80,8 @@ static void shrink_mapping(addr_t new_end) {
     addr_t old_end  = alloc_state.addr;
     size_t size     = old_end - new_end;
 
-    /* Be careful about the possible address overflow here since the mapping
-     * area is at the very top of the address space. This is why we are using
-     * a condition on the offset rather than the address. */
-    for(int offset = 0; offset < size; offset += PAGE_SIZE) {
-        machine_unmap_kernel_page(new_end + offset);
-    }
-    
+    machine_unmap_kernel(new_end, size);
+
     alloc_state.addr            = new_end;
     alloc_state.size_remaining  += size;
 }

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -535,7 +535,7 @@ void pmap_switch_addr_space(addr_space_t *addr_space) {
     cpu_data->current_addr_space = addr_space;
 }
 
-static pte_t *pmap_lookup_page_table(
+static pte_t *lookup_userspace_page_table(
         addr_space_t    *addr_space,
         const void      *addr,
         bool             create_as_needed,
@@ -593,7 +593,34 @@ static pte_t *pmap_lookup_page_table(
 }
 
 /**
- * Lookup a page table entry for a specified address and address space.
+ * Lookup page table entry for specified kernel address
+ *
+ * @param addr kernel address to look up
+ * @return pointer to page table entry
+ *
+ * */
+static pte_t *lookup_kernel_page_table_entry(const void *addr) {
+    /** ASSERTION: addr is aligned on a page boundary */
+    assert( page_offset_of(addr) == 0 );
+
+    /** ASSERTION: addr is a kernel pointer */
+    assert( is_kernel_pointer(addr) );
+
+    /* Fast path for global allocations by the kernel:
+     *  - The page tables for the region just above KLIMIT are pre-allocated
+     *    during the creation of the address space, so there is no need to
+     *    check if they are allocated or to allocate them;
+     *  - The page tables are mapped contiguously at a known location
+     *    during initialization, so no need for a table walk to find them;
+     *  - The mappings for this region are global, so we don't need to
+     *    specify an address space. */
+    return get_pte_with_offset(
+        kernel_page_tables,
+        page_number_of((uintptr_t)addr - KLIMIT));
+}
+
+/**
+ * Lookup page table entry for specified userspace address and address space
  *
  * If the create_as_needed argument is true, new page tables are allocated as
  * needed, and NULL is only returned if allocation of new page tables fail.
@@ -602,47 +629,36 @@ static pte_t *pmap_lookup_page_table(
  *
  * If a new page table is allocated (when create_as_needed is true), CR3 may
  * need to be reloaded. If it's the case, the boolean pointed to by reload_cr3
- * is set to true. Initially setting this boolean to false it the caller's
- * responsibility. The expected sequence of events is as follow:
+ * is set to true. Initially setting this boolean to false is the caller's
+ * responsibility.
  *
  * reload_cr3 must not be NULL if create_as_needed is true but is ignored and
  * can be set to NULL if create_as_needed is false.
  *
  * @param addr_space address space in which the address is looked up.
- * @param addr address to look up
+ * @param addr userspace address to look up
  * @param create_as_needed whether a page table is allocated if it does not exist
  * @param reload_cr3 (out) set to true if CR3 needs to be reloaded
  * @return pointer to page table entry on success, NULL otherwise
  *
  * */
-static pte_t *lookup_page_table_entry(
+static pte_t *lookup_userspace_page_table_entry(
         addr_space_t    *addr_space,
         const void      *addr,
         bool             create_as_needed,
         bool            *reload_cr3) {
-
+    
     /** ASSERTION: addr is aligned on a page boundary */
     assert( page_offset_of(addr) == 0 );
 
-    if(is_kernel_pointer(addr)) {
-        /* Fast path for global allocations by the kernel:
-         *  - The page tables for the region just above KLIMIT are pre-allocated
-         *    during the creation of the address space, so there is no need to
-         *    check if they are allocated or to allocate them;
-         *  - The page tables are mapped contiguously at a known location
-         *    during initialization, so no need for a table walk to find them;
-         *  - The mappings for this region are global, so we don't care
-         *    about the specified address space.  */
-        return get_pte_with_offset(
-                kernel_page_tables,
-                page_number_of((uintptr_t)addr - KLIMIT));
-    }
+    /** ASSERTION: addr is a userspace pointer */
+    assert( is_userspace_pointer(addr) );
 
-    pte_t *page_table = pmap_lookup_page_table(
-            addr_space,
-            addr,
-            create_as_needed,
-            reload_cr3);
+    pte_t *page_table = lookup_userspace_page_table(
+        addr_space,
+        addr,
+        create_as_needed,
+        reload_cr3);
 
     if(page_table == NULL) {
         return NULL;
@@ -671,6 +687,8 @@ static void invalidate_mapping(
         addr_space_t    *addr_space,
         void            *addr,
         bool             reload_cr3) {
+    
+    /* TODO split this function too */
 
     assert(addr_space != NULL || is_kernel_pointer(addr));
 
@@ -722,52 +740,6 @@ static uint64_t map_page_access_flags(int prot) {
 }
 
 /**
- * Map a page frame (physical page) to a virtual memory page.
- *
- * This function is intended to be called by map_userspace_page()) and
- * machine_map_kernel_page(). Either of these functions should be called
- * elsewhere instead of calling this function directly.
- *
- * There is no need to specify an address space for kernel mappings since
- * kernel mappings are global.
- *
- * Page tables are allocated as needed. If an allocation fails, this function
- * returns false to indicate failure.
- *
- * @param addr_space address space in which to map, NULL for kernel mappings
- * @param vaddr virtual address of mapping
- * @param paddr address of page frame
- * @param flags flags used for mapping (see X86_PTE_... constants)
- * @return true on success, false on page table allocation error
- */
-static bool map_page(
-        addr_space_t    *addr_space,
-        void            *vaddr,
-        paddr_t          paddr,
-        uint64_t         flags) {
-
-    /** ASSERTION: we assume vaddr is aligned on a page boundary */
-    assert( page_offset_of(vaddr) == 0 );
-    
-    bool reload_cr3 = false;
-    pte_t *pte = lookup_page_table_entry(addr_space, vaddr, true, &reload_cr3);
-    
-    /* kernel page tables are pre-allocated so this should always succeed for
-     * kernel mappings. */
-    assert(pte != NULL || is_userspace_pointer(vaddr));
-    
-    if(pte == NULL) {
-        return false;
-    }
-
-    set_pte(pte, paddr, flags);
-
-    invalidate_mapping(addr_space, vaddr, reload_cr3);
-
-    return true;
-}
-
-/**
  * Establish a kernel virtual memory mapping for a single page.
  *
  * Kernel page tables are pre-allocated during kernel initialization so this is
@@ -779,8 +751,16 @@ static bool map_page(
  * @param prot protections flags
  */
 void machine_map_kernel_page(void *vaddr, paddr_t paddr, int prot) {
-    assert(is_kernel_pointer(vaddr));
-    map_page(NULL, vaddr, paddr, map_page_access_flags(prot) | X86_PTE_GLOBAL);
+    /** ASSERTION: we assume vaddr is aligned on a page boundary */
+    assert( page_offset_of(vaddr) == 0 );
+
+    pte_t *pte = lookup_kernel_page_table_entry(vaddr);
+
+    assert(pte != NULL);
+
+    set_pte(pte, paddr, map_page_access_flags(prot) | X86_PTE_GLOBAL);
+
+    invalidate_mapping(NULL, vaddr, false);
 }
 
 /**
@@ -801,8 +781,21 @@ static bool map_userspace_page(
         paddr_t          paddr,
         int              prot) {
 
-    assert(is_userspace_pointer(vaddr));
-    return map_page(addr_space, vaddr, paddr, map_page_access_flags(prot) | X86_PTE_USER);
+    /** ASSERTION: we assume vaddr is aligned on a page boundary */
+    assert( page_offset_of(vaddr) == 0 );
+
+    bool reload_cr3 = false;
+    pte_t *pte = lookup_userspace_page_table_entry(addr_space, vaddr, true, &reload_cr3);
+
+    if(pte == NULL) {
+        return false;
+    }
+
+    set_pte(pte, paddr, map_page_access_flags(prot) | X86_PTE_USER);
+
+    invalidate_mapping(addr_space, vaddr, reload_cr3);
+
+    return true;
 }
 
 /**
@@ -843,30 +836,6 @@ bool machine_map_userspace(
 }
 
 /**
- * Unmap a page from virtual memory.
- *
- * There is no need to specify an address space for kernel mappings since
- * kernel mappings are global.
- *
- * This function does not perform any page table deallocation.
- *
- * @param addr_space address space from which to unmap, NULL for kernel mappings
- * @param addr address of page to unmap
- */
-static void unmap_page(addr_space_t *addr_space, void *addr) {
-    /** ASSERTION: addr is aligned on a page boundary */
-    assert( page_offset_of(addr) == 0 );
-    
-    pte_t *pte = lookup_page_table_entry(addr_space, addr, false, NULL);
-    
-    if(pte != NULL) {
-        clear_pte(pte);
-
-        invalidate_mapping(addr_space, addr, false);
-    }
-}
-
-/**
  * Unmap a kernel page from virtual memory.
  *
  * There is no need to specify an address space since kernel mappings are global.
@@ -876,8 +845,16 @@ static void unmap_page(addr_space_t *addr_space, void *addr) {
  * @param addr address of page to unmap
  */
 void machine_unmap_kernel_page(void *addr) {
-    assert(is_kernel_pointer(addr));
-    unmap_page(NULL, addr);
+    /** ASSERTION: addr is aligned on a page boundary */
+    assert( page_offset_of(addr) == 0 );
+
+    pte_t *pte = lookup_kernel_page_table_entry(addr);
+
+    assert(pte != NULL);
+    
+    clear_pte(pte);
+
+    invalidate_mapping(NULL, addr, false);
 }
 
 /**
@@ -887,9 +864,7 @@ void machine_unmap_kernel_page(void *addr) {
  * @return physical address of page frame
  */
 paddr_t machine_lookup_kernel_paddr(const void *addr) {
-    assert( is_kernel_pointer(addr) );
-
-    pte_t *pte = lookup_page_table_entry(NULL, addr, false, NULL);
+    pte_t *pte = lookup_kernel_page_table_entry(addr);
 
     assert(pte != NULL && pte_is_present(pte));
 


### PR DESCRIPTION
* Modify the signature of `machine_map_kernel/userspace()` to take a size argument and allow them to map multiple pages.
* Misc. cleanup and optimizations of mapping/unmapping code.