### PR TITLE
Cleanup up page number and size calculations

### DIFF
--- a/include/kernel/interface/i686/asm/boot.h
+++ b/include/kernel/interface/i686/asm/boot.h
@@ -78,10 +78,8 @@
 
 #define BOOT_SIZE_AT_1MB        (1 * MB)
 
-/* must be a multiple of 4MB (full page tables) */
+/* Must be a multiple of 4MB (full page tables). */
 #define BOOT_SIZE_AT_16MB       (8 * MB)
-
-#define BOOT_PTES_AT_16MB       (BOOT_SIZE_AT_16MB / PAGE_SIZE)
 
 #define BOOT_RAMDISK_LIMIT      0xc0000000
 

--- a/include/kernel/interface/i686/asm/boot.h
+++ b/include/kernel/interface/i686/asm/boot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/kernel/utils/asm/pmap.h
+++ b/include/kernel/utils/asm/pmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -29,43 +29,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_UTILS_PMAP_H
-#define JINUE_KERNEL_UTILS_PMAP_H
+#ifndef JINUE_KERNEL_UTILS_ASM_PMAP_H
+#define JINUE_KERNEL_UTILS_ASM_PMAP_H
 
 #include <kernel/machine/asm/machine.h>
-#include <kernel/utils/asm/pmap.h>
 
-#include <stdbool.h>
-#include <stdint.h>
+#define PAGE_NUMBER(x)  ((x) / PAGE_SIZE)
 
-
-/** byte offset in page of virtual (linear) address */
-#define page_offset_of(x)   ((uintptr_t)(x) & PAGE_MASK)
-
-/** address of the page that contains a virtual (linear) address */
-#define page_address_of(x)  ((uintptr_t)(x) & ~PAGE_MASK)
-
-/** sequential page number of virtual (linear) address */
-#define page_number_of(x)   ((uintptr_t)(x) >> PAGE_BITS)
-
-/** Check whether a pointer points to kernel space */
-static inline bool is_kernel_pointer(const void *addr) {
-    return (uintptr_t)addr >= JINUE_KLIMIT;
-}
-
-/** Check whether a pointer points to user space */
-static inline bool is_userspace_pointer(const void *addr) {
-    return (uintptr_t)addr < JINUE_KLIMIT;
-}
-
-/** Maximum size of user buffer starting at specified address */
-static inline uintptr_t user_pointer_max_size(const void *addr) {
-    return (uintptr_t)JINUE_KLIMIT - (uintptr_t)addr;
-}
-
-/** Check that a buffer is completely in user space */
-static inline bool check_userspace_buffer(const void *addr, uintptr_t size) {
-    return is_userspace_pointer(addr) && size <= user_pointer_max_size(addr);
-}
+#define NUM_PAGES(x)    (((x) + PAGE_SIZE - 1) / PAGE_SIZE)
 
 #endif

--- a/include/kernel/utils/asm/pmap.h
+++ b/include/kernel/utils/asm/pmap.h
@@ -34,8 +34,10 @@
 
 #include <kernel/machine/asm/machine.h>
 
+/** page number for a given byte offset */
 #define PAGE_NUMBER(x)  ((x) / PAGE_SIZE)
 
+/** number of pages, or page table entries, for a given size in bytes */
 #define NUM_PAGES(x)    (((x) + PAGE_SIZE - 1) / PAGE_SIZE)
 
 #endif

--- a/kernel/infrastructure/i686/memory.c
+++ b/kernel/infrastructure/i686/memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Philippe Aubertin.
+ * Copyright (C) 2019-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@
 #include <kernel/infrastructure/i686/memory.h>
 #include <kernel/interface/i686/boot.h>
 #include <kernel/machine/memory.h>
+#include <kernel/utils/pmap.h>
 #include <kernel/utils/utils.h>
 #include <assert.h>
 #include <inttypes.h>
@@ -217,7 +218,7 @@ void memory_initialize_array(
     const size_t entries_per_page = PAGE_SIZE / sizeof(uintptr_t);
 
     const uint64_t memory_top   = memory_find_top(bootinfo);
-    const size_t num_pages      = memory_top / PAGE_SIZE;
+    const size_t num_pages      = NUM_PAGES(memory_top);
     const size_t array_entries  = ALIGN_END(num_pages, entries_per_page);
     const size_t array_pages    = array_entries / entries_per_page;
 
@@ -227,7 +228,7 @@ void memory_initialize_array(
             addr < MEMORY_ADDR_16MB + BOOT_SIZE_AT_16MB;
             addr += PAGE_SIZE) {
 
-        array[addr / PAGE_SIZE] = PHYS_TO_VIRT_AT_16MB(addr);
+        array[page_number_of(addr)] = PHYS_TO_VIRT_AT_16MB(addr);
     }
 
     memory_array            = (uintptr_t *)PHYS_TO_VIRT_AT_16MB(array);
@@ -243,7 +244,7 @@ void memory_initialize_array(
  *
  * */
 void *memory_lookup_page(uint64_t paddr) {
-    uint64_t entry_index = paddr / PAGE_SIZE;
+    uint64_t entry_index = PAGE_NUMBER(paddr);
 
     if(entry_index >= memory_array_entries) {
         return NULL;

--- a/kernel/infrastructure/i686/pmap/pae.c
+++ b/kernel/infrastructure/i686/pmap/pae.c
@@ -128,7 +128,7 @@ static void initialize_boot_mapping_at_16mb(
             next_pte,
             MEMORY_ADDR_16MB + image_size,
             X86_PTE_READ_WRITE,
-            BOOT_PTES_AT_16MB - image_pages);
+            NUM_PAGES(BOOT_SIZE_AT_16MB) - image_pages);
 }
 
 /**
@@ -195,7 +195,7 @@ static void initialize_boot_low_page_directory(
                     pae_page_directory_offset_of((addr_t)MEMORY_ADDR_16MB)),
             (uintptr_t)page_table_16mb,
             X86_PTE_READ_WRITE,
-            BOOT_PTES_AT_16MB / PAGE_TABLE_ENTRIES);
+            NUM_PAGES(BOOT_SIZE_AT_16MB) / PAGE_TABLE_ENTRIES);
 }
 
 /**
@@ -279,7 +279,7 @@ static pdpt_t *initialize_boot_page_tables(
     /* Second mapping (a few page tables) */
     pte_t *page_table_16mb = boot_page_alloc_n(
             boot_alloc,
-            BOOT_PTES_AT_16MB / PAGE_TABLE_ENTRIES);
+            NUM_PAGES(BOOT_SIZE_AT_16MB) / PAGE_TABLE_ENTRIES);
 
     initialize_boot_mapping_at_16mb(page_table_16mb, bootinfo);
 

--- a/kernel/infrastructure/i686/pmap/pae.c
+++ b/kernel/infrastructure/i686/pmap/pae.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -316,7 +316,7 @@ pte_t *initialize_page_table_linear(
  */
 void pmap_write_protect_kernel_image(const bootinfo_t *bootinfo) {
     size_t image_size = (char *)bootinfo->image_top - (char *)bootinfo->image_start;
-    size_t image_pages = image_size / PAGE_SIZE;
+    size_t image_pages = NUM_PAGES(image_size);
 
     for(int idx = 0; idx < image_pages; ++idx) {
         set_pte_flags(
@@ -333,7 +333,7 @@ static void initialize_initial_page_tables(
         const bootinfo_t    *bootinfo) {
 
     size_t image_size  = (char *)bootinfo->image_top - (char *)bootinfo->image_start;
-    size_t image_pages = image_size / PAGE_SIZE;
+    size_t image_pages = NUM_PAGES(image_size);
 
     /* map kernel image read only, not executable */
     pte_t *next_pte_after_image = initialize_page_table_linear(
@@ -347,7 +347,7 @@ static void initialize_initial_page_tables(
             next_pte_after_image,
             MEMORY_ADDR_16MB + image_size,
             X86_PTE_GLOBAL | X86_PTE_READ_WRITE | X86_PTE_NX,
-            BOOT_SIZE_AT_16MB / PAGE_SIZE - image_pages);
+            NUM_PAGES(BOOT_SIZE_AT_16MB) - image_pages);
 
     /* make kernel code segment executable */
     const Elf32_Phdr *phdr = elf_executable_program_header(ehdr);
@@ -358,22 +358,22 @@ static void initialize_initial_page_tables(
 
     uintptr_t code_vaddr    = ALIGN_START((uintptr_t)phdr->p_vaddr, PAGE_SIZE);
     size_t code_size        = phdr->p_memsz + OFFSET_OF_PTR(phdr->p_vaddr, PAGE_SIZE);
-    size_t code_offset      = (code_vaddr - JINUE_KLIMIT) / PAGE_SIZE;
+    size_t code_offset      = page_number_of(code_vaddr - JINUE_KLIMIT);
 
     initialize_page_table_linear(
             get_pte_with_offset(page_tables, code_offset),
             VIRT_TO_PHYS_AT_16MB(code_vaddr),
             X86_PTE_GLOBAL,
-            code_size / PAGE_SIZE);
+            NUM_PAGES(code_size));
 
     /* map kernel data segment */
-    size_t data_offset = ((uintptr_t)bootinfo->data_start - JINUE_KLIMIT) / PAGE_SIZE;
+    size_t data_offset = page_number_of((uintptr_t)bootinfo->data_start - JINUE_KLIMIT);
 
     initialize_page_table_linear(
             get_pte_with_offset(page_tables, data_offset),
             bootinfo->data_physaddr + MEMORY_ADDR_16MB - MEMORY_ADDR_1MB,
             X86_PTE_GLOBAL | X86_PTE_READ_WRITE | X86_PTE_NX,
-            bootinfo->data_size / PAGE_SIZE);
+           NUM_PAGES(bootinfo->data_size));
 }
 
 static void initialize_initial_page_directories(
@@ -398,7 +398,7 @@ addr_space_t *pmap_create_initial_addr_space(
     Elf32_Ehdr *ehdr = kernel->start;
 
     /* Pre-allocate all the kernel page tables. */
-    int num_pages           = (ADDR_4GB - JINUE_KLIMIT) / PAGE_SIZE;
+    int num_pages           = NUM_PAGES(ADDR_4GB - JINUE_KLIMIT);
     int num_page_tables     = num_pages / entries_per_page_table;
 
     /* The number of entries in a pages table (page_table_entries) is also the
@@ -700,7 +700,7 @@ void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot) {
 
     for(size_t offset = 0; offset < size; offset += PAGE_SIZE) {
         set_pte(
-            get_pte_with_offset(pte, offset / PAGE_SIZE),
+            get_pte_with_offset(pte, PAGE_NUMBER(offset)),
             paddr + offset,
             map_page_access_flags(prot) | X86_PTE_GLOBAL
         );
@@ -798,7 +798,7 @@ void machine_unmap_kernel(addr_t addr, size_t size) {
     assert(pte != NULL);
 
     for(size_t offset = 0; offset < size; offset += PAGE_SIZE) {
-        clear_pte( get_pte_with_offset(pte, offset / PAGE_SIZE) );
+        clear_pte( get_pte_with_offset(pte, PAGE_NUMBER(offset)) );
 
         invlpg(addr + offset);
     }

--- a/kernel/interface/i686/setup32.asm
+++ b/kernel/interface/i686/setup32.asm
@@ -1,4 +1,4 @@
-; Copyright (C) 2019-2024 Philippe Aubertin.
+; Copyright (C) 2019-2025 Philippe Aubertin.
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
* Use macros to compute page number and sizes in number of pages to make the code cleaner.
* Eliminate constant `BOOT_PTES_AT_16MB` by replacing it with `NUM_PAGES(BOOT_SIZE_AT_16MB)`.