### PR TITLE
Use ACPI to detect VGA presence

### DIFF
--- a/include/kernel/infrastructure/acpi/tables.h
+++ b/include/kernel/infrastructure/acpi/tables.h
@@ -83,8 +83,12 @@ typedef PACKED_STRUCT {
     uint32_t            entries[];
 } acpi_rsdt_t;
 
-/* ACPI 6.4 section 5.2.9 Fixed ACPI Description Table (FADT) */
-
+/* ACPI 6.4 section 5.2.9 Fixed ACPI Description Table (FADT)
+ *
+ * QEMU seems to present a cropped version compared to the ACPI Specification.
+ * This definition is cropped in the same way to make the QEMU FADT pass the
+ * length check since we are not using the other fields anyway.
+ */
 typedef PACKED_STRUCT {
     acpi_table_header_t header;
     uint32_t            firmware_ctrl;
@@ -125,23 +129,6 @@ typedef PACKED_STRUCT {
     uint16_t            iapc_boot_arch;
     uint8_t             reserved2;
     uint32_t            flags;
-    acpi_gas_t          reset_reg;
-    uint8_t             reset_value;
-    uint16_t            arm_boot_arch;
-    uint8_t             fadt_minor_version;
-    uint64_t            x_firmware_ctrl;
-    uint64_t            x_dsdt;
-    acpi_gas_t          x_pm1a_evt_blk;
-    acpi_gas_t          x_pm1b_evt_blk;
-    acpi_gas_t          x_pm1a_cnt_blk;
-    acpi_gas_t          x_pm1b_cnt_blk;
-    acpi_gas_t          x_pm2_cnt_blk;
-    acpi_gas_t          x_pm_tmr_blk;
-    acpi_gas_t          x_gpe0_blk;
-    acpi_gas_t          x_gpe1_blk;
-    acpi_gas_t          sleep_control_reg;
-    acpi_gas_t          sleep_status_reg;
-    uint64_t            hypervisor_vendor_identity;
 } acpi_fadt_t;
 
 /* ACPI 6.4 section 5.2.12 Multiple APIC Description Table (MADT) */

--- a/include/kernel/infrastructure/acpi/types.h
+++ b/include/kernel/infrastructure/acpi/types.h
@@ -32,6 +32,7 @@
 #ifndef JINUE_KERNEL_INFRASTRUCTURE_ACPI_TYPES_H
 #define JINUE_KERNEL_INFRASTRUCTURE_ACPI_TYPES_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 /* ACPI 6.4 section 15.1 INT 15H, E820H - Query System Address Map */
@@ -45,6 +46,7 @@ typedef struct {
 typedef struct {
     const char   *name;
     const char   *signature;
+    size_t        size;
     const void  **ptr;
 } acpi_table_def_t;
 

--- a/include/kernel/infrastructure/i686/firmware/acpi.h
+++ b/include/kernel/infrastructure/i686/firmware/acpi.h
@@ -33,6 +33,7 @@
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_FIRMWARE_ACPI_H
 
 #include <kernel/infrastructure/i686/types.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 void find_acpi_rsdp(const addr_t first1mb);
@@ -42,5 +43,7 @@ void init_acpi(void);
 void report_acpi(void);
 
 uint32_t acpi_get_rsdp_paddr(void);
+
+bool acpi_is_vga_present(void);
 
 #endif

--- a/kernel/infrastructure/acpi/acpi.c
+++ b/kernel/infrastructure/acpi/acpi.c
@@ -212,6 +212,7 @@ static void match_table(const acpi_table_header_t *header, const acpi_table_def_
         }
 
         *def->ptr = map_table(header);
+        return;
     }
 
     undo_map_in_kernel();

--- a/kernel/infrastructure/acpi/acpi.c
+++ b/kernel/infrastructure/acpi/acpi.c
@@ -198,11 +198,20 @@ static const acpi_rsdt_t *map_rsdt(uint64_t rsdt_paddr, bool is_xsdt) {
 static void match_table(const acpi_table_header_t *header, const acpi_table_def_t *table_defs) {
     for(int idx = 0; table_defs[idx].signature != NULL; ++idx) {
         const acpi_table_def_t *def = &table_defs[idx];
-        
-        if(*def->ptr == NULL && verify_table_signature(header, def->signature)) {
-            *def->ptr = map_table(header);
-            return;
+
+        if(*def->ptr != NULL) {
+            continue;
         }
+
+        if(!verify_table_signature(header, def->signature)) {
+            continue;
+        }
+
+        if(header->length < def->size) {
+            continue;
+        }
+
+        *def->ptr = map_table(header);
     }
 
     undo_map_in_kernel();

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -34,6 +34,7 @@
 #include <kernel/domain/services/logging.h>
 #include <kernel/domain/services/mman.h>
 #include <kernel/infrastructure/i686/drivers/vga.h>
+#include <kernel/infrastructure/i686/firmware/acpi.h>
 #include <kernel/infrastructure/i686/isa/io.h>
 #include <kernel/infrastructure/i686/pmap/pmap.h>
 #include <kernel/utils/asm/ascii.h>
@@ -61,6 +62,10 @@ static void vga_clear(void) {
 
 void vga_init(const config_t *config) {
     if(! config->machine.vga_enable) {
+        return;
+    }
+
+    if(!acpi_is_vga_present()) {
         return;
     }
     

--- a/kernel/infrastructure/i686/firmware/acpi.c
+++ b/kernel/infrastructure/i686/firmware/acpi.c
@@ -54,16 +54,19 @@ static const acpi_table_def_t table_defs[] = {
     {
         .name       = ACPI_FADT_NAME,
         .signature  = ACPI_FADT_SIGNATURE,
+        .size       = sizeof(acpi_fadt_t),
         .ptr        = (const void **)&acpi_tables.fadt
     },
     {
         .name       = ACPI_MADT_NAME,
         .signature  = ACPI_MADT_SIGNATURE,
+        .size       = sizeof(acpi_madt_t),
         .ptr        = (const void **)&acpi_tables.madt
     },
     {
         .name       = ACPI_HPET_NAME,
         .signature  = ACPI_HPET_SIGNATURE,
+        .size       = sizeof(acpi_hpet_t),
         .ptr        = (const void **)&acpi_tables.hpet
     },
     { .signature  = NULL },

--- a/kernel/infrastructure/i686/firmware/acpi.c
+++ b/kernel/infrastructure/i686/firmware/acpi.c
@@ -167,3 +167,22 @@ void report_acpi(void) {
 uint32_t acpi_get_rsdp_paddr(void) {
     return rsdp_paddr;
 }
+
+/**
+ * Detect presence of VGA
+ * 
+ * From the description if bit 2 "VGA Not Present" of IAPC_BOOT_ARCH in Table
+ * 5.11 of the ACPI Specification:
+ * 
+ * " If set, indicates to OSPM that it must not blindly probe the VGA hardware
+ *   (that responds to MMIO addresses A0000h-BFFFFh and IO ports 3B0h-3BBh and
+ *   3C0h-3DFh) that may cause machine check on this system. If clear,
+ *   indicates to OSPM that it is safe to probe the VGA hardware. "
+ */
+bool acpi_is_vga_present(void) {
+    if(acpi_tables.fadt == NULL) {
+        return true;
+    }
+
+    return !(acpi_tables.fadt->iapc_boot_arch & ACPI_IAPC_BOOT_ARCH_VGA_NOT_PRESENT);
+}


### PR DESCRIPTION
Use ACPI to detect whether VGA is present or not. Do not attempt to initialize or use VGA if it is not present.