### PR TITLE
Do not truncate command line in log

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Debug with GDB",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/kernel/interface/i686/kernel",
+            "miDebuggerServerAddress": "localhost:1234",
+            "cwd": "${workspaceRoot}",
+            "externalConsole": true,
+            "linux": {
+                "MIMode": "gdb"
+            }
+        }
+    
+    ]
+}

--- a/include/kernel/domain/services/cmdline.h
+++ b/include/kernel/domain/services/cmdline.h
@@ -56,4 +56,6 @@ bool cmdline_match_enum(
 
 bool cmdline_match_boolean(bool *value, const cmdline_token_t *token);
 
+void cmdline_report_options(const char *cmdline);
+
 #endif

--- a/include/kernel/domain/services/cmdline.h
+++ b/include/kernel/domain/services/cmdline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Philippe Aubertin.
+ * Copyright (C) 2022-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/application/kmain.c
+++ b/kernel/application/kmain.c
@@ -59,9 +59,8 @@ void kmain(const char *cmdline) {
 
     info("Jinue microkernel started.");
     info("Kernel revision " GIT_REVISION " built " BUILD_TIME " on " BUILD_HOST);
-    info("Kernel command line:");
-    info("%s", cmdline);
-    info("---");
+
+    cmdline_report_options(cmdline);
 
     /* If there were issues parsing the command line, these will be reported
      * here (i.e. panic), now that logging has been initialized and we can log

--- a/kernel/application/kmain.c
+++ b/kernel/application/kmain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/domain/services/cmdline.c
+++ b/kernel/domain/services/cmdline.c
@@ -1011,3 +1011,25 @@ size_t cmdline_count_environ(const char *cmdline) {
 
     return count;
 }
+
+/**
+ * Report the command line in the logs
+ *
+ * @param cmdline command line string
+ *
+ * */
+void cmdline_report_options(const char *cmdline) {
+    info("Command line:");
+
+    const char *line = cmdline;
+
+    while(*line != '\0') {
+        int idx;
+
+        for(idx = 0; idx < 78 && line[idx] != '\0'; ++idx) {}
+
+        info("  %.*s", idx, line);
+
+        line = &line[idx];
+    }
+}

--- a/kernel/domain/services/cmdline.c
+++ b/kernel/domain/services/cmdline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Philippe Aubertin.
+ * Copyright (C) 2022-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -1014,22 +1014,41 @@ size_t cmdline_count_environ(const char *cmdline) {
 
 /**
  * Report the command line in the logs
+ * 
+ * Wrap lines so the command line is not truncated. When wrapping, make a
+ * reasonable effort to not break individual options.
  *
  * @param cmdline command line string
  *
  * */
 void cmdline_report_options(const char *cmdline) {
+#define MAX_LENGTH 80
+#define MIN_LENGTH 40
+
     info("Command line:");
 
     const char *line = cmdline;
 
     while(*line != '\0') {
         int idx;
+        int last_space = -1;
 
-        for(idx = 0; idx < 78 && line[idx] != '\0'; ++idx) {}
+        /* minus two for the two spaces used as indentation */
+        for(idx = 0; idx < MAX_LENGTH - 2 && line[idx] != '\0'; ++idx) {
+            if(isspace(line[idx])) {
+                last_space = idx;
+            }
+        }
 
-        info("  %.*s", idx, line);
+        const char *format = "  %.*s";
 
-        line = &line[idx];
+        if(last_space >= MIN_LENGTH) {
+            info(format, last_space, line);
+            line = &line[last_space + 1];
+        }
+        else {
+            info(format, idx, line);
+            line = &line[idx];
+        }        
     }
 }

--- a/userspace/lib/libc/vsnprintf.c
+++ b/userspace/lib/libc/vsnprintf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Philippe Aubertin.
+ * Copyright (C) 2022-2025 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -447,6 +447,7 @@ static void parse_precision(conv_spec_t *spec, state_t *state, va_list *args) {
         consume(state);
 
         if(current(state) == '*') {
+            consume(state);
             spec->prec = va_arg(*args, int);
 
             if(spec->prec < 0) {


### PR DESCRIPTION
When logging the kernel command line, wrap it instead of truncating it.