### PR TITLE
Pentium support

### DIFF
--- a/header.mk
+++ b/header.mk
@@ -116,13 +116,13 @@ endif
 #
 # These flags are used when preprocessing C and assembly language files.
 CPPFLAGS.includes    = -I$(includes)
-CPPFLAGS.arch        = -m32 -march=i686
+CPPFLAGS.arch        = -m32 -march=pentium -mtune=generic
 CPPFLAGS.others      = -nostdinc
 CPPFLAGS             = $(CPPFLAGS.arch) $(CPPFLAGS.includes) $(CPPFLAGS.debug) $(CPPFLAGS.others) $(CPPFLAGS.extra)
 
 # C compiler flags
 CFLAGS.warnings      = -std=c99 -pedantic -Wall -Wno-array-bounds -Werror=implicit -Werror=uninitialized -Werror=return-type
-CFLAGS.arch          = -m32 -march=i686
+CFLAGS.arch          = -m32 -march=pentium -mtune=generic
 CFLAGS.optimization  = -O3
 CFLAGS.others        = -ffreestanding -fno-pie -fno-common -fno-omit-frame-pointer -fno-delete-null-pointer-checks -fno-asynchronous-unwind-tables
 CFLAGS               = $(CFLAGS.arch) $(CFLAGS.optimization) $(CFLAGS.debug) $(CFLAGS.warnings) $(CFLAGS.others) $(CFLAGS.extra)

--- a/include/jinue/shared/asm/machine.h
+++ b/include/jinue/shared/asm/machine.h
@@ -32,7 +32,7 @@
 #ifndef _JINUE_SHARED_ASM_MACHINE_H
 #define _JINUE_SHARED_ASM_MACHINE_H
 
-#ifdef __i686__
+#ifdef __i386__
 #include <jinue/shared/asm/i686.h>
 #endif
 

--- a/include/kernel/machine/asm/machine.h
+++ b/include/kernel/machine/asm/machine.h
@@ -34,7 +34,7 @@
 
 #include <jinue/shared/asm/machine.h>
 
-#ifdef __i686__
+#ifdef __i386__
 #include <kernel/infrastructure/i686/exports/asm/machine.h>
 #endif
 

--- a/include/kernel/machine/spinlock.h
+++ b/include/kernel/machine/spinlock.h
@@ -35,7 +35,7 @@
 #include <kernel/machine/types.h>
 
 /* Must define SPINLOCK_INITIALIZER. */
-#ifdef __i686__
+#ifdef __i386__
 #include <kernel/infrastructure/i686/exports/spinlock.h>
 #endif
 

--- a/include/kernel/machine/types.h
+++ b/include/kernel/machine/types.h
@@ -32,7 +32,7 @@
 #ifndef JINUE_KERNEL_MACHINE_TYPES_H
 #define JINUE_KERNEL_MACHINE_TYPES_H
 
-#ifdef __i686__
+#ifdef __i386__
 #include <kernel/infrastructure/i686/exports/types.h>
 #endif
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,7 +34,7 @@ kernel_ldscript  = interface/i686/ld/kernel.ld
 image_ldscript   = interface/i686/ld/image.ld
 build_info_h     = build-info.gen.h
 
-LDFLAGS         += -m32 -march=i686
+LDFLAGS         += -m32 $(CFLAGS.arch)
 KERNEL_LDFLAGS   = -T $(kernel_ldscript)
 KERNEL_LDLIBS    = -lgcc
 IMAGE_LDFLAGS    = -T $(image_ldscript)

--- a/tests/test_486_too_old.sh
+++ b/tests/test_486_too_old.sh
@@ -1,4 +1,5 @@
-# Copyright (C) 2019-2023 Philippe Aubertin.
+#!/bin/bash
+# Copyright (C) 2025 Philippe Aubertin.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,54 +28,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-jinue_root = ../..
-include $(jinue_root)/header.mk
+CPU=486
 
-sources.c        = \
-	archives/alloc.c \
-	archives/tar.c \
-	binfmt/elf.c \
-	core/mappings.c \
-	core/meminfo.c \
-	core/server.c \
-	streams/bzip2.c \
-	streams/gzip.c \
-	streams/raw.c \
-	streams/stream.c \
-	debug.c \
-	loader.c \
-	ramdisk.c \
-	utils.c
-loader           = loader
-target           = $(loader)-stripped
+run
 
-CPPFLAGS        += -I$(zlib) -DZLIB_CONST -I$(bzip2) -DBZ_NO_STDIO
+check_kernel_start
 
-# The linker might not link crt.o from libjinue.a, which is required to
-# provide the _start entry point but otherwise contains no symbol that
-# other object files are interested in. I have seen different behaviour
-# in this regard on different machines with different versions of the
-# linker. By explicitly forcing _start as an undefined symbol, we
-# ensure the linker links the startup code.
-LDFLAGS         += -Wl,-u,_start $(CFLAGS.arch)
-LDLIBS           = -lgcc
-
-unclean.extra    = $(loader)
-
-include $(common)
-
-$(libjinue_syscalls) $(libjinue_utils): FORCE
-	$(MAKE) -C $(libjinue)
-	
-$(libc)/libc.a: FORCE
-	$(MAKE) -C $(libc)
-
-$(zlib)/libz.a: FORCE
-	$(MAKE) CC=$(CC) -C $(zlib) libz.a
-
-$(bzip2)/libbz2.a: FORCE
-	$(MAKE) CC=$(CC) -C $(bzip2) libbz2.a
-
-$(loader): $(objects) $(libjinue_utils) $(zlib)/libz.a $(bzip2)/libbz2.a $(libc)/libc.a $(libjinue_syscalls)
-
-$(target): $(loader)
+echo "* Check CPU was detected as too old"
+grep -F "Pentium CPU or later is required" $LOG || fail

--- a/userspace/testapp/Makefile
+++ b/userspace/testapp/Makefile
@@ -45,7 +45,7 @@ unclean_recursive	 = $(temp_ramdisk_fs)
 # in this regard on different machines with different versions of the
 # linker. By explicitly forcing _start as an undefined symbol, we
 # ensure the linker links the startup code.
-LDFLAGS         += -Wl,-u,_start -m32 -march=i686
+LDFLAGS         += -Wl,-u,_start $(CFLAGS.arch)
 LDLIBS           = -lgcc
 
 unclean.extra    = $(testapp) $(stripped)


### PR DESCRIPTION
Adjust compilation flags to ensure the kernel can boot on a Pentium CPU, which is what we check for as the minimum supported CPU.