### PR TITLE
Cursor shadow cursor position for VGA

### DIFF
--- a/include/kernel/infrastructure/i686/drivers/asm/vga.h
+++ b/include/kernel/infrastructure/i686/drivers/asm/vga.h
@@ -35,10 +35,20 @@
 #define VGA_TEXT_VID_BASE           0xb8000
 #define VGA_TEXT_VID_TOP            0xc0000
 #define VGA_TEXT_VID_SIZE           (VGA_TEXT_VID_TOP - VGA_TEXT_VID_BASE)
+#define VGA_ATTR_WR_AND_ADDR        0x3c0
+#define VGA_ATTR_RD                 0x3c1
 #define VGA_MISC_OUT_WR             0x3c2
+#define VGA_SEQ_ADDR                0x3c4
+#define VGA_SEQ_DATA                0x3c5
 #define VGA_MISC_OUT_RD             0x3cc
+#define VGA_GRAPHICS_ADDR           0x3ce
+#define VGA_GRAPHICS_DATA	        0x3cf
 #define VGA_CRTC_ADDR               0x3d4
 #define VGA_CRTC_DATA               0x3d5
+#define VGA_IN_STATUS1              0x3da
+
+#define VGA_CRTC_CURSOR_HIGH        0x0e
+#define VGA_CRTC_CURSOR_LOW         0x0f
 
 #define VGA_FB_FLAG_ACTIVE    1
 

--- a/include/kernel/utils/utils.h
+++ b/include/kernel/utils/utils.h
@@ -43,4 +43,6 @@
 
 #define ALIGN_END_PTR(x, s)     ( (void *)ALIGN_END((uintptr_t)(x), (s)) )
 
+#define ARRAY_COUNT(ar)         (sizeof(ar) / sizeof(ar[0]))
+
 #endif

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -75,14 +75,12 @@ static void write_misc_out_reg(uint8_t value) {
     outb(VGA_MISC_OUT_WR, value);
 }
 
-/** Write a value to one of the sequencer registers
+/** Read a value from the misc. output register.
  * 
- * @param index index of register to write to
- * @param value value to write in register
+ * @return register value
  */
-static void write_seq_reg(unsigned int index, uint8_t value) {
-    outb(VGA_SEQ_ADDR, index);
-    outb(VGA_SEQ_DATA, value);
+static uint8_t read_misc_out_reg(void) {
+    return inb(VGA_MISC_OUT_RD);
 }
 
 /** Write a value to one of the CRT Controller (CRTC) registers.
@@ -97,72 +95,8 @@ static void write_seq_reg(unsigned int index, uint8_t value) {
  * @param value value to write in register
  */
 static void write_crtc_reg(unsigned int index, uint8_t value) {
-    if(index == 0x03) {
-        value |= 0x80;
-    }
-
-    if(index == 0x11) {
-        value &= ~0x80;
-    }
-
     outb(VGA_CRTC_ADDR, index);
     outb(VGA_CRTC_DATA, value);
-}
-
-/** Read the value from one of the CRT Controller (CRTC) registers.
- * 
- * @param index index of register to write to
- */
-static uint8_t read_crtc_reg(unsigned int index) {
-    outb(VGA_CRTC_ADDR, index);
-    return inb(VGA_CRTC_DATA);
-}
-
-/** Unprotect CRT Controller (CRTC) registers with indexes 0-7. */
-static void unprotect_crtc_regs(void) {
-    /* write_crtc_reg() tweaks the values for the right CRTC registers to
-     * unprotect. We only need to read and re-write the relevant registers. */
-    write_crtc_reg(0x03, read_crtc_reg(0x03));
-    write_crtc_reg(0x11, read_crtc_reg(0x11));
-}
-
-/** Write a value to one of the graphics controller registers.
- * 
- * @param index index of register to write to
- * @param value value to write in register
- */
-static void write_graphics_reg(unsigned int index, uint8_t value) {
-    outb(VGA_GRAPHICS_ADDR, index);
-    outb(VGA_GRAPHICS_DATA, value);
-}
-
-/** Write a value to one of the attribute controller registers.
- * 
- * @param index index of register to write to
- * @param value value to write in register
- */
-static void write_attr_reg(unsigned int index, uint8_t value) {
-    /* The same register is used to set the address and value. We need to read
-     * the input status 1 register first, which will cause the attribute
-     * controller register to expect the index. */
-    (void)inb(VGA_IN_STATUS1);
-    outb(VGA_ATTR_WR_AND_ADDR, index);
-    outb(VGA_ATTR_WR_AND_ADDR, value);
-}
-
-/** Indicate we are done writing to the attribute controller registers.
- * 
- * This is required because either the host or the VGTA hardware has exclusive
- * access to these registers.
-*/
-static void done_with_attr_regs(void) {
-    /* Bit 5 in the attributes controller index register controls who can
-     * access the palette registers: 0 for host and 1 for video memory. It
-     * must be cleared to set the palette registers and then set again to
-     * allow them to be used by the VGA hardware. It is set by this
-     * function. */
-    (void)inb(VGA_IN_STATUS1);
-    outb(VGA_ATTR_WR_AND_ADDR, 0x20);
 }
 
 /** Get the current position of the text cursor.
@@ -215,62 +149,10 @@ static int map_color(int loglevel) {
     }
 }
 
-/** Initialize VGA to 80x25 text mode */
-static void initialize_text_mode(void) {
-    /* Source for register values: https://files.osdev.org/mirrors/geezer/osd/graphics/modes.c
-     * (See g_80x25_text and write_regs(), public domain, thanks to Chris Giese.)
-     * 
-     * The misc. output register must be written first because its LSB sets
-     * the address of the CRTC registers (0x3dx in our case). */
-    write_misc_out_reg(0x67);
-
-    /* sequencer registers values */
-    
-    const uint8_t seq_regvals[] = {0x03, 0x00, 0x03, 0x00, 0x02};
-
-    for(int idx = 0; idx < ARRAY_COUNT(seq_regvals); ++idx) {
-        write_seq_reg(idx, seq_regvals[idx]);
-    }
-
-    /* CRTC registers */
-    
-    const uint8_t crtc_regvals[] = {
-        0x5f, 0x4f, 0x50, 0x82, 0x55, 0x81, 0xbf, 0x1f,
-        0x00, 0x4f, 0x0d, 0x0e, 0x00, 0x00, 0x00, 0x50,
-        0x9c, 0x0e, 0x8f, 0x28, 0x1f, 0x96, 0xb9, 0xa3,
-        0xff
-    };
-
-    unprotect_crtc_regs();
-
-    for(int idx = 0; idx < ARRAY_COUNT(crtc_regvals); ++idx) {
-        write_crtc_reg(idx, crtc_regvals[idx]);
-    }
-
-    /* Graphics controller registers */
-    
-    const uint8_t graphics_regvals[] = {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x0e, 0x00,
-	    0xff,
-    };
-
-    for(int idx = 0; idx < ARRAY_COUNT(graphics_regvals); ++idx) {
-        write_graphics_reg(idx, graphics_regvals[idx]);
-    }
-
-    /* Attribute controller registers */
-    
-    const uint8_t attr_regvals[] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x14, 0x07,
-        0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
-        0x0c, 0x00, 0x0f, 0x08, 0x00
-    };
-
-    for(int idx = 0; idx < ARRAY_COUNT(attr_regvals); ++idx) {
-        write_attr_reg(idx, attr_regvals[idx]);
-    }
-
-    done_with_attr_regs();
+/** Initialize registers */
+static void initialize_registers(void) {
+    /* Set address select bit in a known state: CRTC regs at 0x3dx */
+    write_misc_out_reg(read_misc_out_reg() | 1);
 }
 
 /** Scroll the text buffer by one line. */
@@ -372,7 +254,7 @@ void vga_init(const config_t *config) {
         return;
     }
 
-    initialize_text_mode();
+    initialize_registers();
 
     /* Move cursor to line 0 col 0 */
     set_cursor_position(0);

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -41,15 +41,23 @@
 #include <kernel/utils/pmap.h>
 #include <kernel/utils/utils.h>
 
+/** type for the current linear position in the text buffer */
 typedef unsigned int vga_pos_t;
 
+/** current cursor/next write position in the text buffer
+ * 
+ *  Position in number of characters (not bytes, there are two bytes per
+ *  character in the text buffer because of the attributes).
+ */
+static vga_pos_t cursor_pos;
+
+/** log ring buffer reader */
 static log_reader_t log_reader;
 
 /** base address of the VGA text video buffer */
 static unsigned char *video_base_addr;
 
-static vga_pos_t cursor_pos;
-
+/** Erase the VGA text buffer. */
 static void vga_clear(void) {
     unsigned int idx = 0;
     
@@ -59,17 +67,36 @@ static void vga_clear(void) {
     }
 }
 
+/** Write a value to the misc. output register.
+ * 
+ * @param value value to write in register
+ */
 static void write_misc_out_reg(uint8_t value) {
     outb(VGA_MISC_OUT_WR, value);
 }
 
+/** Write a value to one of the sequencer registers
+ * 
+ * @param index index of register to write to
+ * @param value value to write in register
+ */
 static void write_seq_reg(unsigned int index, uint8_t value) {
     outb(VGA_SEQ_ADDR, index);
     outb(VGA_SEQ_DATA, value);
 }
 
+/** Write a value to one of the CRT Controller (CRTC) registers.
+ * 
+ * When writing to register index 3, this function automatically sets the test
+ * bit (bit 7) that must be written to one.
+ * 
+ * When writing to register index 17 (0x11), this function automatically clears
+ * bit 7 to unprotect CRTC registers witth indexes 0-7.
+ * 
+ * @param index index of register to write to
+ * @param value value to write in register
+ */
 static void write_crtc_reg(unsigned int index, uint8_t value) {
-    /* unprotect or keep unprotected */
     if(index == 0x03) {
         value |= 0x80;
     }
@@ -82,11 +109,16 @@ static void write_crtc_reg(unsigned int index, uint8_t value) {
     outb(VGA_CRTC_DATA, value);
 }
 
+/** Read the value from one of the CRT Controller (CRTC) registers.
+ * 
+ * @param index index of register to write to
+ */
 static uint8_t read_crtc_reg(unsigned int index) {
     outb(VGA_CRTC_ADDR, index);
     return inb(VGA_CRTC_DATA);
 }
 
+/** Unprotect CRT Controller (CRTC) registers with indexes 0-7. */
 static void unprotect_crtc_regs(void) {
     /* write_crtc_reg() tweaks the values for the right CRTC registers to
      * unprotect. We only need to read and re-write the relevant registers. */
@@ -94,11 +126,21 @@ static void unprotect_crtc_regs(void) {
     write_crtc_reg(0x11, read_crtc_reg(0x11));
 }
 
+/** Write a value to one of the graphics controller registers.
+ * 
+ * @param index index of register to write to
+ * @param value value to write in register
+ */
 static void write_graphics_reg(unsigned int index, uint8_t value) {
     outb(VGA_GRAPHICS_ADDR, index);
     outb(VGA_GRAPHICS_DATA, value);
 }
 
+/** Write a value to one of the attribute controller registers.
+ * 
+ * @param index index of register to write to
+ * @param value value to write in register
+ */
 static void write_attr_reg(unsigned int index, uint8_t value) {
     /* The same register is used to set the address and value. We need to read
      * the input status 1 register first, which will cause the attribute
@@ -108,6 +150,11 @@ static void write_attr_reg(unsigned int index, uint8_t value) {
     outb(VGA_ATTR_WR_AND_ADDR, value);
 }
 
+/** Indicate we are done writing to the attribute controller registers.
+ * 
+ * This is required because either the host or the VGTA hardware has exclusive
+ * access to these registers.
+*/
 static void done_with_attr_regs(void) {
     /* Bit 5 in the attributes controller index register controls who can
      * access the palette registers: 0 for host and 1 for video memory. It
@@ -118,11 +165,24 @@ static void done_with_attr_regs(void) {
     outb(VGA_ATTR_WR_AND_ADDR, 0x20);
 }
 
-static vga_pos_t vga_get_cursor_pos(void) {
+/** Get the current position of the text cursor.
+ * 
+ * The position is obtained from the shadow variable.
+ * 
+ * @return the current linear position of the text cursor
+ */
+static vga_pos_t get_cursor_position(void) {
     return cursor_pos;
 }
 
-static void vga_set_cursor_pos(vga_pos_t pos) {
+/** Set the position of the text cursor.
+ * 
+ * This function updates both the the relevant hardware register and the shadow
+ * variable.
+ * 
+ * @param pos linear position of the text cursor
+ */
+static void set_cursor_position(vga_pos_t pos) {
     cursor_pos = pos;
 
     unsigned char h = pos >> 8;
@@ -132,7 +192,12 @@ static void vga_set_cursor_pos(vga_pos_t pos) {
     write_crtc_reg(VGA_CRTC_CURSOR_LOW, l);   
 }
 
-static int get_color(int loglevel) {
+/** Map a log level to the appropriate VGA colour number.
+ * 
+ * @param loglevel the log level
+ * @return VGA colour number
+ */
+static int map_color(int loglevel) {
     switch(loglevel) {
     case JINUE_LOG_LEVEL_EMERGENCY:
     case JINUE_LOG_LEVEL_ALERT:
@@ -150,7 +215,66 @@ static int get_color(int loglevel) {
     }
 }
 
-static void vga_scroll(void) {
+/** Initialize VGA to 80x25 text mode */
+static void initialize_text_mode(void) {
+    /* Source for register values: https://files.osdev.org/mirrors/geezer/osd/graphics/modes.c
+     * (See g_80x25_text and write_regs(), public domain, thanks to Chris Giese.)
+     * 
+     * The misc. output register must be written first because its LSB sets
+     * the address of the CRTC registers (0x3dx in our case). */
+    write_misc_out_reg(0x67);
+
+    /* sequencer registers values */
+    
+    const uint8_t seq_regvals[] = {0x03, 0x00, 0x03, 0x00, 0x02};
+
+    for(int idx = 0; idx < ARRAY_COUNT(seq_regvals); ++idx) {
+        write_seq_reg(idx, seq_regvals[idx]);
+    }
+
+    /* CRTC registers */
+    
+    const uint8_t crtc_regvals[] = {
+        0x5f, 0x4f, 0x50, 0x82, 0x55, 0x81, 0xbf, 0x1f,
+        0x00, 0x4f, 0x0d, 0x0e, 0x00, 0x00, 0x00, 0x50,
+        0x9c, 0x0e, 0x8f, 0x28, 0x1f, 0x96, 0xb9, 0xa3,
+        0xff
+    };
+
+    unprotect_crtc_regs();
+
+    for(int idx = 0; idx < ARRAY_COUNT(crtc_regvals); ++idx) {
+        write_crtc_reg(idx, crtc_regvals[idx]);
+    }
+
+    /* Graphics controller registers */
+    
+    const uint8_t graphics_regvals[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x0e, 0x00,
+	    0xff,
+    };
+
+    for(int idx = 0; idx < ARRAY_COUNT(graphics_regvals); ++idx) {
+        write_graphics_reg(idx, graphics_regvals[idx]);
+    }
+
+    /* Attribute controller registers */
+    
+    const uint8_t attr_regvals[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x14, 0x07,
+        0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+        0x0c, 0x00, 0x0f, 0x08, 0x00
+    };
+
+    for(int idx = 0; idx < ARRAY_COUNT(attr_regvals); ++idx) {
+        write_attr_reg(idx, attr_regvals[idx]);
+    }
+
+    done_with_attr_regs();
+}
+
+/** Scroll the text buffer by one line. */
+static void scroll_text(void) {
     unsigned char *di = video_base_addr;
     unsigned char *si = video_base_addr + 2 * VGA_WIDTH;
     unsigned int idx;
@@ -165,7 +289,13 @@ static void vga_scroll(void) {
     }
 }
 
-static vga_pos_t vga_raw_putc(char c, vga_pos_t pos, int colour) {
+/** Write a character in the text buffer
+ * 
+ * @param c character to write
+ * @param pos position at which to write the character
+ * @param colour color number
+ */
+static vga_pos_t write_character(char c, vga_pos_t pos, int colour) {
     const vga_pos_t limit = VGA_WIDTH * VGA_LINES;
     
     switch(c) {
@@ -202,26 +332,37 @@ static vga_pos_t vga_raw_putc(char c, vga_pos_t pos, int colour) {
     
     if(pos >= limit) {
         pos -= VGA_WIDTH;
-        vga_scroll();
+        scroll_text();
     }
     
     return pos;
 }
 
+/** Logging callback function.
+ * 
+ * This function is registered as the logging callback function and is called
+ * by the logging infrastructure for each logging event.
+ * 
+ * @param event logging event
+*/
 static void do_log(const log_event_t *event) {
-    int colour = get_color(event->loglevel);
+    int colour = map_color(event->loglevel);
 
-    vga_pos_t pos  = vga_get_cursor_pos();
+    vga_pos_t pos  = get_cursor_position();
 
     for(int idx = 0; idx < event->length && event->message[idx] != '\0'; ++idx) {
-        pos = vga_raw_putc(event->message[idx], pos, colour);
+        pos = write_character(event->message[idx], pos, colour);
     }
     
-    pos = vga_raw_putc('\n', pos, colour);
+    pos = write_character('\n', pos, colour);
 
-    vga_set_cursor_pos(pos);
+    set_cursor_position(pos);
 }
 
+/** Initialize VGA for logging.
+ * 
+ * @param config kernel configuration
+ */
 void vga_init(const config_t *config) {
     if(! config->machine.vga_enable) {
         return;
@@ -231,61 +372,10 @@ void vga_init(const config_t *config) {
         return;
     }
 
-    /* Initialize VGA to 80x25 text mode
-     *
-     * Source for register values: https://files.osdev.org/mirrors/geezer/osd/graphics/modes.c
-     * (See g_80x25_text and write_regs(), public domain, thanks to Chris Giese.)
-     * 
-     * The misc. output register must be written first because its LSB sets
-     * the address of the CRTC registers (0x3dx in our case). */
-    write_misc_out_reg(0x67);
-
-    /* sequencer registers values */
-    const uint8_t seq_regvals[] = {0x03, 0x00, 0x03, 0x00, 0x02};
-
-    for(int idx = 0; idx < ARRAY_COUNT(seq_regvals); ++idx) {
-        write_seq_reg(idx, seq_regvals[idx]);
-    }
-
-    /* CRTC registers */
-    const uint8_t crtc_regvals[] = {
-        0x5f, 0x4f, 0x50, 0x82, 0x55, 0x81, 0xbf, 0x1f,
-        0x00, 0x4f, 0x0d, 0x0e, 0x00, 0x00, 0x00, 0x50,
-        0x9c, 0x0e, 0x8f, 0x28, 0x1f, 0x96, 0xb9, 0xa3,
-        0xff
-    };
-
-    unprotect_crtc_regs();
-
-    for(int idx = 0; idx < ARRAY_COUNT(crtc_regvals); ++idx) {
-        write_crtc_reg(idx, crtc_regvals[idx]);
-    }
-
-    /* Graphics controller registers */
-    const uint8_t graphics_regvals[] = {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x0e, 0x00,
-	    0xff,
-    };
-
-    for(int idx = 0; idx < ARRAY_COUNT(graphics_regvals); ++idx) {
-        write_graphics_reg(idx, graphics_regvals[idx]);
-    }
-
-    /* Attribute controller registers */
-    const uint8_t attr_regvals[] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x14, 0x07,
-        0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
-        0x0c, 0x00, 0x0f, 0x08, 0x00
-    };
-
-    for(int idx = 0; idx < ARRAY_COUNT(attr_regvals); ++idx) {
-        write_attr_reg(idx, attr_regvals[idx]);
-    }
-
-    done_with_attr_regs();
+    initialize_text_mode();
 
     /* Move cursor to line 0 col 0 */
-    vga_set_cursor_pos(0);
+    set_cursor_position(0);
 
     video_base_addr = map_in_kernel(
         VGA_TEXT_VID_BASE,

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -48,6 +48,8 @@ static log_reader_t log_reader;
 /** base address of the VGA text video buffer */
 static unsigned char *video_base_addr;
 
+static vga_pos_t cursor_pos;
+
 static void vga_clear(void) {
     unsigned int idx = 0;
     
@@ -117,15 +119,12 @@ static void done_with_attr_regs(void) {
 }
 
 static vga_pos_t vga_get_cursor_pos(void) {
-    unsigned char h, l;
-    
-    h = read_crtc_reg(VGA_CRTC_CURSOR_HIGH);
-    l = read_crtc_reg(VGA_CRTC_CURSOR_LOW);
-    
-    return (h << 8) | l;
+    return cursor_pos;
 }
 
 static void vga_set_cursor_pos(vga_pos_t pos) {
+    cursor_pos = pos;
+
     unsigned char h = pos >> 8;
     unsigned char l = pos;
 

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -39,6 +39,7 @@
 #include <kernel/infrastructure/i686/platform.h>
 #include <kernel/utils/asm/ascii.h>
 #include <kernel/utils/pmap.h>
+#include <kernel/utils/utils.h>
 
 typedef unsigned int vga_pos_t;
 
@@ -56,13 +57,70 @@ static void vga_clear(void) {
     }
 }
 
+static void write_misc_out_reg(uint8_t value) {
+    outb(VGA_MISC_OUT_WR, value);
+}
+
+static void write_seq_reg(unsigned int index, uint8_t value) {
+    outb(VGA_SEQ_ADDR, index);
+    outb(VGA_SEQ_DATA, value);
+}
+
+static void write_crtc_reg(unsigned int index, uint8_t value) {
+    /* unprotect or keep unprotected */
+    if(index == 0x03) {
+        value |= 0x80;
+    }
+
+    if(index == 0x11) {
+        value &= ~0x80;
+    }
+
+    outb(VGA_CRTC_ADDR, index);
+    outb(VGA_CRTC_DATA, value);
+}
+
+static uint8_t read_crtc_reg(unsigned int index) {
+    outb(VGA_CRTC_ADDR, index);
+    return inb(VGA_CRTC_DATA);
+}
+
+static void unprotect_crtc_regs(void) {
+    /* write_crtc_reg() tweaks the values for the right CRTC registers to
+     * unprotect. We only need to read and re-write the relevant registers. */
+    write_crtc_reg(0x03, read_crtc_reg(0x03));
+    write_crtc_reg(0x11, read_crtc_reg(0x11));
+}
+
+static void write_graphics_reg(unsigned int index, uint8_t value) {
+    outb(VGA_GRAPHICS_ADDR, index);
+    outb(VGA_GRAPHICS_DATA, value);
+}
+
+static void write_attr_reg(unsigned int index, uint8_t value) {
+    /* The same register is used to set the address and value. We need to read
+     * the input status 1 register first, which will cause the attribute
+     * controller register to expect the index. */
+    (void)inb(VGA_IN_STATUS1);
+    outb(VGA_ATTR_WR_AND_ADDR, index);
+    outb(VGA_ATTR_WR_AND_ADDR, value);
+}
+
+static void done_with_attr_regs(void) {
+    /* Bit 5 in the attributes controller index register controls who can
+     * access the palette registers: 0 for host and 1 for video memory. It
+     * must be cleared to set the palette registers and then set again to
+     * allow them to be used by the VGA hardware. It is set by this
+     * function. */
+    (void)inb(VGA_IN_STATUS1);
+    outb(VGA_ATTR_WR_AND_ADDR, 0x20);
+}
+
 static vga_pos_t vga_get_cursor_pos(void) {
     unsigned char h, l;
     
-    outb(VGA_CRTC_ADDR, 0x0e);
-    h = inb(VGA_CRTC_DATA);
-    outb(VGA_CRTC_ADDR, 0x0f);
-    l = inb(VGA_CRTC_DATA);
+    h = read_crtc_reg(VGA_CRTC_CURSOR_HIGH);
+    l = read_crtc_reg(VGA_CRTC_CURSOR_LOW);
     
     return (h << 8) | l;
 }
@@ -70,11 +128,9 @@ static vga_pos_t vga_get_cursor_pos(void) {
 static void vga_set_cursor_pos(vga_pos_t pos) {
     unsigned char h = pos >> 8;
     unsigned char l = pos;
-    
-    outb(VGA_CRTC_ADDR, 0x0e);
-    outb(VGA_CRTC_DATA, h);
-    outb(VGA_CRTC_ADDR, 0x0f);
-    outb(VGA_CRTC_DATA, l);    
+
+    write_crtc_reg(VGA_CRTC_CURSOR_HIGH, h);
+    write_crtc_reg(VGA_CRTC_CURSOR_LOW, l);   
 }
 
 static int get_color(int loglevel) {
@@ -156,7 +212,7 @@ static vga_pos_t vga_raw_putc(char c, vga_pos_t pos, int colour) {
 static void do_log(const log_event_t *event) {
     int colour = get_color(event->loglevel);
 
-    unsigned short int pos  = vga_get_cursor_pos();
+    vga_pos_t pos  = vga_get_cursor_pos();
 
     for(int idx = 0; idx < event->length && event->message[idx] != '\0'; ++idx) {
         pos = vga_raw_putc(event->message[idx], pos, colour);
@@ -175,18 +231,62 @@ void vga_init(const config_t *config) {
     if(!platform_is_vga_present()) {
         return;
     }
-    
-    /* Set address select bit in a known state: CRTC regs at 0x3dx */
-    unsigned char data;
-    data = inb(VGA_MISC_OUT_RD);
-    data |= 1;
-    outb(VGA_MISC_OUT_WR, data);
+
+    /* Initialize VGA to 80x25 text mode
+     *
+     * Source for register values: https://files.osdev.org/mirrors/geezer/osd/graphics/modes.c
+     * (See g_80x25_text and write_regs(), public domain, thanks to Chris Giese.)
+     * 
+     * The misc. output register must be written first because its LSB sets
+     * the address of the CRTC registers (0x3dx in our case). */
+    write_misc_out_reg(0x67);
+
+    /* sequencer registers values */
+    const uint8_t seq_regvals[] = {0x03, 0x00, 0x03, 0x00, 0x02};
+
+    for(int idx = 0; idx < ARRAY_COUNT(seq_regvals); ++idx) {
+        write_seq_reg(idx, seq_regvals[idx]);
+    }
+
+    /* CRTC registers */
+    const uint8_t crtc_regvals[] = {
+        0x5f, 0x4f, 0x50, 0x82, 0x55, 0x81, 0xbf, 0x1f,
+        0x00, 0x4f, 0x0d, 0x0e, 0x00, 0x00, 0x00, 0x50,
+        0x9c, 0x0e, 0x8f, 0x28, 0x1f, 0x96, 0xb9, 0xa3,
+        0xff
+    };
+
+    unprotect_crtc_regs();
+
+    for(int idx = 0; idx < ARRAY_COUNT(crtc_regvals); ++idx) {
+        write_crtc_reg(idx, crtc_regvals[idx]);
+    }
+
+    /* Graphics controller registers */
+    const uint8_t graphics_regvals[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x0e, 0x00,
+	    0xff,
+    };
+
+    for(int idx = 0; idx < ARRAY_COUNT(graphics_regvals); ++idx) {
+        write_graphics_reg(idx, graphics_regvals[idx]);
+    }
+
+    /* Attribute controller registers */
+    const uint8_t attr_regvals[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x14, 0x07,
+        0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+        0x0c, 0x00, 0x0f, 0x08, 0x00
+    };
+
+    for(int idx = 0; idx < ARRAY_COUNT(attr_regvals); ++idx) {
+        write_attr_reg(idx, attr_regvals[idx]);
+    }
+
+    done_with_attr_regs();
 
     /* Move cursor to line 0 col 0 */
-    outb(VGA_CRTC_ADDR, 0x0e);
-    outb(VGA_CRTC_DATA, 0x0);    
-    outb(VGA_CRTC_ADDR, 0x0f);
-    outb(VGA_CRTC_DATA, 0x0);
+    vga_set_cursor_pos(0);
 
     video_base_addr = map_in_kernel(
         VGA_TEXT_VID_BASE,


### PR DESCRIPTION
* Use shadow position for VGA cursor instead of continuously reading the position registers.
* Add function header comments for VGA code.
* General cleanup of VGA code.