### PR TITLE
Write combining with Page Attribute Table (PAT)

### DIFF
--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/jinue/jinue.h
+++ b/include/jinue/jinue.h
@@ -78,6 +78,7 @@ int jinue_mmap(
         void        *addr,
         size_t       length,
         int          prot,
+        int          flags,
         uint64_t     paddr,
         int         *perrno);
 

--- a/include/jinue/shared/asm/mman.h
+++ b/include/jinue/shared/asm/mman.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/jinue/shared/types.h
+++ b/include/jinue/shared/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/jinue/shared/types.h
+++ b/include/jinue/shared/types.h
@@ -96,6 +96,7 @@ typedef struct {
     void        *addr;
     size_t       length;
     int          prot;
+    int          flags;
     uint64_t     paddr;
 } jinue_mmap_args_t;
 

--- a/include/kernel/domain/services/mman.h
+++ b/include/kernel/domain/services/mman.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Philippe Aubertin.
+ * Copyright (C) 2025-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/kernel/domain/services/mman.h
+++ b/include/kernel/domain/services/mman.h
@@ -35,7 +35,7 @@
 #include <kernel/machine/types.h>
 #include <stddef.h>
 
-void *map_in_kernel(paddr_t paddr, size_t size, int prot);
+void *map_in_kernel(paddr_t paddr, size_t size, int prot, int flags);
 
 void resize_map_in_kernel(size_t size);
 

--- a/include/kernel/infrastructure/i686/asm/cpuid.h
+++ b/include/kernel/infrastructure/i686/asm/cpuid.h
@@ -85,6 +85,8 @@
 
 #define CPUID_FEATURE_CLFLUSH           (1<<19)
 
+#define CPUID_FEATURE_SSE               (1<<25)
+
 #define CPUID_FEATURE_HTT               (1<<28)
 
 /* Software/hypervisor leaf 0 (0x40000000) ebx, ecx, edx */

--- a/include/kernel/infrastructure/i686/asm/cpuid.h
+++ b/include/kernel/infrastructure/i686/asm/cpuid.h
@@ -79,7 +79,11 @@
 
 #define CPUID_FEATURE_SEP               (1<<11)
 
+#define CPUID_FEATURE_MTRR              (1<<12)
+
 #define CPUID_FEATURE_PGE               (1<<13)
+
+#define CPUID_FEATURE_PAT               (1<<16)
 
 #define CPUID_FEATURE_CLFLUSH           (1<<19)
 

--- a/include/kernel/infrastructure/i686/asm/cpuid.h
+++ b/include/kernel/infrastructure/i686/asm/cpuid.h
@@ -79,8 +79,6 @@
 
 #define CPUID_FEATURE_SEP               (1<<11)
 
-#define CPUID_FEATURE_MTRR              (1<<12)
-
 #define CPUID_FEATURE_PGE               (1<<13)
 
 #define CPUID_FEATURE_PAT               (1<<16)

--- a/include/kernel/infrastructure/i686/asm/cpuinfo.h
+++ b/include/kernel/infrastructure/i686/asm/cpuinfo.h
@@ -38,15 +38,19 @@
 
 #define CPU_FEATURE_CPUID       (1<<1)
 
-#define CPU_FEATURE_NX          (1<<2)
+#define CPU_FEATURE_MTRR        (1<<2)
 
-#define CPU_FEATURE_PAE         (1<<3)
+#define CPU_FEATURE_NX          (1<<3)
 
-#define CPU_FEATURE_PGE         (1<<4)
+#define CPU_FEATURE_PAE         (1<<4)
 
-#define CPU_FEATURE_SYSCALL     (1<<5)
+#define CPU_FEATURE_PAT         (1<<5)
 
-#define CPU_FEATURE_SYSENTER    (1<<6)
+#define CPU_FEATURE_PGE         (1<<6)
+
+#define CPU_FEATURE_SYSCALL     (1<<7)
+
+#define CPU_FEATURE_SYSENTER    (1<<8)
 
 /* vendors */
 

--- a/include/kernel/infrastructure/i686/asm/cpuinfo.h
+++ b/include/kernel/infrastructure/i686/asm/cpuinfo.h
@@ -38,17 +38,17 @@
 
 #define CPU_FEATURE_CPUID       (1<<1)
 
-#define CPU_FEATURE_NX          (1<<4)
+#define CPU_FEATURE_NX          (1<<2)
 
-#define CPU_FEATURE_PAE         (1<<5)
+#define CPU_FEATURE_PAE         (1<<3)
 
-#define CPU_FEATURE_PAT         (1<<6)
+#define CPU_FEATURE_PAT         (1<<4)
 
-#define CPU_FEATURE_PGE         (1<<7)
+#define CPU_FEATURE_PGE         (1<<5)
 
-#define CPU_FEATURE_SYSCALL     (1<<8)
+#define CPU_FEATURE_SYSCALL     (1<<6)
 
-#define CPU_FEATURE_SYSENTER    (1<<9)
+#define CPU_FEATURE_SYSENTER    (1<<7)
 
 /* vendors */
 

--- a/include/kernel/infrastructure/i686/asm/cpuinfo.h
+++ b/include/kernel/infrastructure/i686/asm/cpuinfo.h
@@ -38,19 +38,17 @@
 
 #define CPU_FEATURE_CPUID       (1<<1)
 
-#define CPU_FEATURE_MTRR        (1<<2)
+#define CPU_FEATURE_NX          (1<<4)
 
-#define CPU_FEATURE_NX          (1<<3)
+#define CPU_FEATURE_PAE         (1<<5)
 
-#define CPU_FEATURE_PAE         (1<<4)
+#define CPU_FEATURE_PAT         (1<<6)
 
-#define CPU_FEATURE_PAT         (1<<5)
+#define CPU_FEATURE_PGE         (1<<7)
 
-#define CPU_FEATURE_PGE         (1<<6)
+#define CPU_FEATURE_SYSCALL     (1<<8)
 
-#define CPU_FEATURE_SYSCALL     (1<<7)
-
-#define CPU_FEATURE_SYSENTER    (1<<8)
+#define CPU_FEATURE_SYSENTER    (1<<9)
 
 /* vendors */
 

--- a/include/kernel/infrastructure/i686/asm/msr.h
+++ b/include/kernel/infrastructure/i686/asm/msr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/kernel/infrastructure/i686/asm/msr.h
+++ b/include/kernel/infrastructure/i686/asm/msr.h
@@ -32,11 +32,17 @@
 #ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_MSR_H
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_MSR_H
 
+#define MSR_IA32_MTRRCAP            0xfe
+
 #define MSR_IA32_SYSENTER_CS        0x174
 
 #define MSR_IA32_SYSENTER_ESP       0x175
 
 #define MSR_IA32_SYSENTER_EIP       0x176
+
+#define MSR_IA32_PAT                0x277
+
+#define MSR_IA32_MTRR_DEF_TYPE      0x2ff
 
 #define MSR_EFER                    0xC0000080
 

--- a/include/kernel/infrastructure/i686/asm/pat.h
+++ b/include/kernel/infrastructure/i686/asm/pat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -29,28 +29,50 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _JINUE_SHARED_ASM_MMAN_H
-#define _JINUE_SHARED_ASM_MMAN_H
+#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_PAT_H
+#define JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_PAT_H
 
-/** map page with no access permission */
-#define JINUE_PROT_NONE         0
+/** Uncacheable */
+#define PAT_UC          0
 
-/** map page with read permission */
-#define JINUE_PROT_READ         (1<<0)
+/** Write-Combining */
+#define PAT_WC          1
 
-/** map page with write permission */
-#define JINUE_PROT_WRITE        (1<<1)
+/** Write-Through */
+#define PAT_WT          4
 
-/** map page with execution permission */
-#define JINUE_PROT_EXEC         (1<<2)
+/** Write-Protected */
+#define PAT_WP          5
 
-/** no mapping flags */
-#define JINUE_MAP_NONE          0
+/** Write-Back */
+#define PAT_WB          6
 
-/** map as uncacheable memory */
-#define JINUE_MAP_UNCACHEABLE   (1<<0)
+/** Uncached minus (can be overridden by MTRR WC) */
+#define PAT_UC_MINUS    7
 
-/** map as write-combining memory */
-#define JINUE_MAP_WRITE_COMBINE (1<<1)
+
+/** PAT entry 0 */
+#define PAT0    0
+
+/** PAT entry 1 */
+#define PAT1    8
+
+/** PAT entry 2 */
+#define PAT2    16
+
+/** PAT entry 3 */
+#define PAT3    24
+
+/** PAT entry 4 */
+#define PAT4    32
+
+/** PAT entry 5 */
+#define PAT5    40
+
+/** PAT entry 6 */
+#define PAT6    48
+
+/** PAT entry 7 */
+#define PAT7    56
 
 #endif

--- a/include/kernel/infrastructure/i686/asm/x86.h
+++ b/include/kernel/infrastructure/i686/asm/x86.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/kernel/infrastructure/i686/asm/x86.h
+++ b/include/kernel/infrastructure/i686/asm/x86.h
@@ -65,10 +65,10 @@
 #define X86_PTE_USER                (1<< 2)
 
 /** write-through cache policy for page */
-#define X86_PTE_WRITE_THROUGH       (1<< 3)
+#define X86_PTE_PWT                 (1<< 3)
 
 /** uncached page */
-#define X86_PTE_CACHE_DISABLE       (1<< 4)
+#define X86_PTE_PCD                 (1<< 4)
 
 /** page was accessed (read) */
 #define X86_PTE_ACCESSED            (1<< 5)

--- a/include/kernel/infrastructure/i686/asm/x86.h
+++ b/include/kernel/infrastructure/i686/asm/x86.h
@@ -39,6 +39,12 @@
 /** CR0 register: Write Protect */
 #define X86_CR0_WP                  (1<<16)
 
+/** CR0 register: Not Write-through */
+#define X86_CR0_NW                  (1<<29)
+
+/** CR0 register: Cache Disable */
+#define X86_CR0_CD                  (1<<30)
+
 /** CR0 register: Paging */
 #define X86_CR0_PG                  (1<<31)
 

--- a/include/kernel/infrastructure/i686/barriers.h
+++ b/include/kernel/infrastructure/i686/barriers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2026 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -29,63 +29,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_CPUINFO_H
-#define JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_CPUINFO_H
+#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_BARRIERS_H
+#define JINUE_KERNEL_INFRASTRUCTURE_I686_BARRIERS_H
 
-/* features */
-
-#define CPU_FEATURE_APIC        (1<<0)
-
-#define CPU_FEATURE_CPUID       (1<<1)
-
-#define CPU_FEATURE_NX          (1<<2)
-
-#define CPU_FEATURE_PAE         (1<<3)
-
-#define CPU_FEATURE_PAT         (1<<4)
-
-#define CPU_FEATURE_PGE         (1<<5)
-
-#define CPU_FEATURE_SSE         (1<<6)
-
-#define CPU_FEATURE_SYSCALL     (1<<7)
-
-#define CPU_FEATURE_SYSENTER    (1<<8)
-
-/* vendors */
-
-#define CPU_VENDOR_GENERIC          0
-
-#define CPU_VENDOR_AMD              1
-
-#define CPU_VENDOR_CENTAUR_VIA      2
-
-#define CPU_VENDOR_CYRIX            3
-
-#define CPU_VENDOR_HYGON            4
-
-#define CPU_VENDOR_INTEL            5
-
-#define CPU_VENDOR_ZHAOXIN          6
-
-/* hypervisors */
-
-#define HYPERVISOR_ID_NONE          0
-
-#define HYPERVISOR_ID_UNKNOWN       1
-
-#define HYPERVISOR_ID_ACRN          2
-
-#define HYPERVISOR_ID_BHYVE         3
-
-#define HYPERVISOR_ID_HYPER_V       4
-
-#define HYPERVISOR_ID_KVM           5
-
-#define HYPERVISOR_ID_QEMU          6
-
-#define HYPERVISOR_ID_VMWARE        7
-
-#define HYPERVISOR_ID_XEN           8
+void store_barrier(void);
 
 #endif

--- a/include/kernel/infrastructure/i686/caches.h
+++ b/include/kernel/infrastructure/i686/caches.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2026 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -29,31 +29,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_INSTRS_H
-#define JINUE_KERNEL_INFRASTRUCTURE_I686_INSTRS_H
+#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_CACHES_H
+#define JINUE_KERNEL_INFRASTRUCTURE_I686_CACHES_H
 
-#include <kernel/infrastructure/i686/types.h>
+void enable_caches(void);
 
-void cli(void);
+void disable_caches(void);
 
-void sti(void);
+void invalidate_caches(void);
 
-void hlt(void);
-
-void invlpg(void *vaddr);
-
-void lgdt(pseudo_descriptor_t *gdt_info);
-
-void lidt(pseudo_descriptor_t *idt_info);
-
-void ltr(seg_selector_t sel);
-
-uint64_t rdmsr(uint32_t addr);
-
-void wrmsr(uint32_t addr, uint64_t val);
-
-void sfence(void);
-
-void wbinvd(void);
+void invalidate_all_tlb(void);
 
 #endif

--- a/include/kernel/infrastructure/i686/isa/instrs.h
+++ b/include/kernel/infrastructure/i686/isa/instrs.h
@@ -52,4 +52,6 @@ uint64_t rdmsr(uint32_t addr);
 
 void wrmsr(uint32_t addr, uint64_t val);
 
+void sfence(void);
+
 #endif

--- a/include/kernel/infrastructure/i686/isa/instrs.h
+++ b/include/kernel/infrastructure/i686/isa/instrs.h
@@ -54,6 +54,8 @@ void wrmsr(uint32_t addr, uint64_t val);
 
 void sfence(void);
 
+void sfence_fallback(void);
+
 void wbinvd(void);
 
 #endif

--- a/include/kernel/infrastructure/i686/pmap/pae.h
+++ b/include/kernel/infrastructure/i686/pmap/pae.h
@@ -47,7 +47,7 @@ pte_t *pae_lookup_page_directory(
         addr_space_t    *addr_space,
         const void      *addr,
         bool             create_as_needed,
-        bool            *reload_cr3);
+        bool            *must_reload_cr3);
 
 unsigned int pae_page_table_offset_of(const void *addr);
 

--- a/include/kernel/machine/pmap.h
+++ b/include/kernel/machine/pmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Philippe Aubertin.
+ * Copyright (C) 2024-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/kernel/machine/pmap.h
+++ b/include/kernel/machine/pmap.h
@@ -34,7 +34,7 @@
 
 #include <kernel/types.h>
 
-void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot);
+void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot, int flags);
 
 void machine_unmap_kernel(addr_t addr, size_t size);
 
@@ -43,7 +43,8 @@ bool machine_map_userspace(
         addr_t           addr,
         size_t           length,
         paddr_t          paddr,
-        int              prot);
+        int              prot,
+        int              flags);
 
 paddr_t machine_lookup_kernel_paddr(const void *addr);
 

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Philippe Aubertin.
+ * Copyright (C) 2023-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -45,17 +45,25 @@
 #define PROT_EXEC   JINUE_PROT_EXEC
 
 
-#define MAP_SHARED      (1<<0)
+#define MAP_UNCACHEABLE     JINUE_MAP_UNCACHEABLE
 
-#define MAP_PRIVATE     (1<<1)
+#define MAP_WRITE_COMBINE   JINUE_MAP_WRITE_COMBINE
 
-#define MAP_FIXED       (1<<2)
+/* Keep the flags below allocated downward starting from bit 31 since the
+ * JINUE_MAP_xx flags are allocated starting from bit 0. */
 
-#define MAP_ANONYMOUS   (1<<3)
+#define MAP_SHARED          (1<<28)
 
-#define MAP_ANON        MAP_ANONYMOUS
+#define MAP_PRIVATE         (1<<29)
 
-#define MAP_FAILED      ((void *)-1)
+#define MAP_FIXED           (1<<30)
+
+#define MAP_ANONYMOUS       (1<<31)
+
+#define MAP_ANON            MAP_ANONYMOUS
+
+
+#define MAP_FAILED          ((void *)-1)
 
 
 void *mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -119,6 +119,7 @@ sources.kernel.c = \
 	infrastructure/i686/pmap/pae.c \
 	infrastructure/i686/boot_alloc.c \
 	infrastructure/i686/cmdline.c \
+	infrastructure/i686/caches.c \
 	infrastructure/i686/config.c \
 	infrastructure/i686/cpuidsig.c \
 	infrastructure/i686/cpuinfo.c \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -117,9 +117,10 @@ sources.kernel.c = \
 	infrastructure/i686/pmap/nopae.c \
 	infrastructure/i686/pmap/pmap.c \
 	infrastructure/i686/pmap/pae.c \
+	infrastructure/i686/barriers.c \
 	infrastructure/i686/boot_alloc.c \
-	infrastructure/i686/cmdline.c \
 	infrastructure/i686/caches.c \
+	infrastructure/i686/cmdline.c \
 	infrastructure/i686/config.c \
 	infrastructure/i686/cpuidsig.c \
 	infrastructure/i686/cpuinfo.c \

--- a/kernel/application/syscalls/mmap.c
+++ b/kernel/application/syscalls/mmap.c
@@ -30,6 +30,7 @@
  */
 
 #include <jinue/shared/asm/errno.h>
+#include <jinue/shared/asm/mman.h>
 #include <kernel/application/syscalls.h>
 #include <kernel/domain/entities/descriptor.h>
 #include <kernel/domain/entities/process.h>
@@ -46,11 +47,16 @@ int with_process(descriptor_t *process_desc, const jinue_mmap_args_t *args) {
         return -JINUE_EPERM;
     }
 
-    if(! machine_map_userspace(process, args->addr, args->length, args->paddr, args->prot)) {
-        return -JINUE_ENOMEM;
-    }
+    bool success = machine_map_userspace(
+        process,
+        args->addr,
+        args->length,
+        args->paddr,
+        args->prot,
+        JINUE_MAP_NONE
+    );
 
-    return 0;
+    return success ? 0 : -JINUE_ENOMEM;
 }
 
 

--- a/kernel/application/syscalls/mmap.c
+++ b/kernel/application/syscalls/mmap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Philippe Aubertin.
+ * Copyright (C) 2024-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ int with_process(descriptor_t *process_desc, const jinue_mmap_args_t *args) {
         args->length,
         args->paddr,
         args->prot,
-        JINUE_MAP_NONE
+        args->flags
     );
 
     return success ? 0 : -JINUE_ENOMEM;

--- a/kernel/domain/alloc/page_alloc.c
+++ b/kernel/domain/alloc/page_alloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/domain/alloc/page_alloc.c
+++ b/kernel/domain/alloc/page_alloc.c
@@ -125,7 +125,7 @@ bool add_page_frame(paddr_t paddr) {
         return false;
     }
 
-    machine_map_kernel(page, PAGE_SIZE, paddr, JINUE_PROT_READ | JINUE_PROT_WRITE);
+    machine_map_kernel(page, PAGE_SIZE, paddr, JINUE_PROT_READ | JINUE_PROT_WRITE, JINUE_MAP_NONE);
 
     /* Since this page is coming from userspace, is is important to clear it:
      * 1) The page may contain sensitive information, which we don't want to

--- a/kernel/domain/services/mman.c
+++ b/kernel/domain/services/mman.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Philippe Aubertin.
+ * Copyright (C) 2025-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/domain/services/mman.c
+++ b/kernel/domain/services/mman.c
@@ -42,11 +42,13 @@ static struct {
     addr_t       addr;
     const void  *latest_addr;
     int          latest_prot;
+    int          latest_flags;
     size_t       size_remaining;
 } alloc_state = {
     .addr           = (addr_t)MAPPING_AREA_ADDR,
     .latest_addr    = NULL,
     .latest_prot    = JINUE_PROT_NONE,
+    .latest_flags   = JINUE_MAP_NONE,
     .size_remaining = MAPPING_AREA_SIZE,
 };
 
@@ -55,9 +57,10 @@ static struct {
  * 
  * @param paddr physical address of start, must be page-aligned
  * @param new_end new end of the expanded mapping, must be page aligned
- * @param prot mapping protection flags
+ * @param prot protection flags
+ * @param flags mapping flags
  */
-static void expand_mapping(paddr_t paddr, addr_t new_end, int prot) {
+static void expand_mapping(paddr_t paddr, addr_t new_end, int prot, int flags) {
     addr_t old_end  = alloc_state.addr;
     size_t size     = new_end - old_end;
 
@@ -65,7 +68,7 @@ static void expand_mapping(paddr_t paddr, addr_t new_end, int prot) {
         panic("No more space to map memory in kernel");
     }
 
-    machine_map_kernel(old_end, size, paddr, prot);
+    machine_map_kernel(old_end, size, paddr, prot, flags);
 
     alloc_state.addr            = new_end;
     alloc_state.size_remaining  -= size;
@@ -101,9 +104,10 @@ static void shrink_mapping(addr_t new_end) {
  * 
  * @param paddr address to memory map
  * @param size size of memory to map, cannot be zero
- * @param prot mapping protection flags
+ * @param prot protection flags
+ * @param flags mapping flags
  */
-void *map_in_kernel(paddr_t paddr, size_t size, int prot) {
+void *map_in_kernel(paddr_t paddr, size_t size, int prot, int flags) {
     size_t offset   = paddr % PAGE_SIZE;
 
     addr_t start    = alloc_state.addr;
@@ -111,8 +115,9 @@ void *map_in_kernel(paddr_t paddr, size_t size, int prot) {
     
     alloc_state.latest_addr = start + offset;
     alloc_state.latest_prot = prot;
+    alloc_state.latest_flags = flags;
 
-    expand_mapping(paddr - offset, end, prot);
+    expand_mapping(paddr - offset, end, prot, flags);
 
     return start + offset;
 }
@@ -134,11 +139,12 @@ void resize_map_in_kernel(size_t size) {
         shrink_mapping(new_end);
     } else {
         int prot        = alloc_state.latest_prot;
+        int flags       = alloc_state.latest_flags;
 
         addr_t start    = ALIGN_START_PTR(addr, PAGE_SIZE);
         paddr_t paddr   = machine_lookup_kernel_paddr(start) + (old_end - start);
 
-        expand_mapping(paddr, new_end, prot);
+        expand_mapping(paddr, new_end, prot, flags);
     }
 }
 
@@ -156,4 +162,5 @@ void undo_map_in_kernel(void) {
     
     alloc_state.latest_addr = NULL;
     alloc_state.latest_prot = JINUE_PROT_NONE;
+    alloc_state.latest_flags = JINUE_MAP_NONE;
 }

--- a/kernel/infrastructure/acpi/acpi.c
+++ b/kernel/infrastructure/acpi/acpi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Philippe Aubertin.
+ * Copyright (C) 2025-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/infrastructure/acpi/acpi.c
+++ b/kernel/infrastructure/acpi/acpi.c
@@ -110,7 +110,7 @@ static bool verify_table_signature(const acpi_table_header_t *header, const char
 static const acpi_rsdp_t *map_rsdp(paddr_t paddr) {
     machine_add_shared_to_address_map(paddr, sizeof(acpi_rsdp_t));
 
-    return map_in_kernel(paddr, sizeof(acpi_rsdp_t), JINUE_PROT_READ);
+    return map_in_kernel(paddr, sizeof(acpi_rsdp_t), JINUE_PROT_READ, JINUE_MAP_NONE);
 }
 
 /**
@@ -146,7 +146,7 @@ static const void *map_table(const acpi_table_header_t *header) {
  *
  * */
 static const acpi_table_header_t *map_header(paddr_t paddr) {
-    return map_in_kernel(paddr, sizeof(acpi_table_header_t), JINUE_PROT_READ);
+    return map_in_kernel(paddr, sizeof(acpi_table_header_t), JINUE_PROT_READ, JINUE_MAP_NONE);
 }
 
 /** Size of the fixed part of the RSDT, excluding the entries. */

--- a/kernel/infrastructure/elf.c
+++ b/kernel/infrastructure/elf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/infrastructure/elf.c
+++ b/kernel/infrastructure/elf.c
@@ -144,20 +144,20 @@ bool elf_check(Elf32_Ehdr *ehdr) {
  * @param process address space for the mapping
  * @param vadds virtual address of page
  * @param padds physical address of page frame
- * @param flags mapping flags
+ * @param prot protection flags
  *
  */
 static void checked_map_userspace_page(
         process_t       *process,
         void            *vaddr,
         paddr_t          paddr,
-        int              flags) {
+        int              prot) {
 
     /* TODO check user space pointers
      *
      * This should not be necessary because we control the user loader binary,
      * but let's check anyway in case the build process breaks somehow. */
-    if(! machine_map_userspace(process, vaddr, PAGE_SIZE, paddr, flags)) {
+    if(! machine_map_userspace(process, vaddr, PAGE_SIZE, paddr, prot, JINUE_MAP_NONE)) {
         panic("Page table allocation error when loading ELF file");
     }
 }
@@ -247,7 +247,7 @@ static addr_t get_at_phdr(const Elf32_Ehdr *ehdr) {
  * @return start of stack in loader address space
  *
  */
-static int map_flags(Elf32_Word p_flags) {
+static int map_protection_flags(Elf32_Word p_flags) {
     /* set flags */
     int flags = 0;
 
@@ -319,7 +319,7 @@ static void load_segments(
                         process,
                         vptr,
                         machine_lookup_kernel_paddr(file_ptr),
-                        map_flags(phdr->p_flags));
+                        map_protection_flags(phdr->p_flags));
 
                 vptr     += PAGE_SIZE;
                 file_ptr += PAGE_SIZE;
@@ -339,7 +339,7 @@ static void load_segments(
                         process,
                         vptr,
                         machine_lookup_kernel_paddr(page),
-                        map_flags(phdr->p_flags));
+                        map_protection_flags(phdr->p_flags));
 
                 /* TODO transfer page ownership to userspace */
 

--- a/kernel/infrastructure/i686/barriers.c
+++ b/kernel/infrastructure/i686/barriers.c
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2019-2026 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the author nor the names of other contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,63 +29,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_CPUINFO_H
-#define JINUE_KERNEL_INFRASTRUCTURE_I686_ASM_CPUINFO_H
+#include <kernel/infrastructure/i686/isa/instrs.h>
+#include <kernel/infrastructure/i686/barriers.h>
+#include <kernel/infrastructure/i686/cpuinfo.h>
 
-/* features */
-
-#define CPU_FEATURE_APIC        (1<<0)
-
-#define CPU_FEATURE_CPUID       (1<<1)
-
-#define CPU_FEATURE_NX          (1<<2)
-
-#define CPU_FEATURE_PAE         (1<<3)
-
-#define CPU_FEATURE_PAT         (1<<4)
-
-#define CPU_FEATURE_PGE         (1<<5)
-
-#define CPU_FEATURE_SSE         (1<<6)
-
-#define CPU_FEATURE_SYSCALL     (1<<7)
-
-#define CPU_FEATURE_SYSENTER    (1<<8)
-
-/* vendors */
-
-#define CPU_VENDOR_GENERIC          0
-
-#define CPU_VENDOR_AMD              1
-
-#define CPU_VENDOR_CENTAUR_VIA      2
-
-#define CPU_VENDOR_CYRIX            3
-
-#define CPU_VENDOR_HYGON            4
-
-#define CPU_VENDOR_INTEL            5
-
-#define CPU_VENDOR_ZHAOXIN          6
-
-/* hypervisors */
-
-#define HYPERVISOR_ID_NONE          0
-
-#define HYPERVISOR_ID_UNKNOWN       1
-
-#define HYPERVISOR_ID_ACRN          2
-
-#define HYPERVISOR_ID_BHYVE         3
-
-#define HYPERVISOR_ID_HYPER_V       4
-
-#define HYPERVISOR_ID_KVM           5
-
-#define HYPERVISOR_ID_QEMU          6
-
-#define HYPERVISOR_ID_VMWARE        7
-
-#define HYPERVISOR_ID_XEN           8
-
-#endif
+void store_barrier(void) {
+    /* the sfence instruction was introduced with SSE. */
+    if(cpu_has_feature(CPU_FEATURE_SSE)) {
+        sfence();
+    }
+    else {
+        sfence_fallback();
+    }
+}

--- a/kernel/infrastructure/i686/caches.c
+++ b/kernel/infrastructure/i686/caches.c
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2019-2026 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the author nor the names of other contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,31 +29,37 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef JINUE_KERNEL_INFRASTRUCTURE_I686_INSTRS_H
-#define JINUE_KERNEL_INFRASTRUCTURE_I686_INSTRS_H
+#include <kernel/infrastructure/i686/asm/x86.h>
+#include <kernel/infrastructure/i686/isa/instrs.h>
+#include <kernel/infrastructure/i686/isa/regs.h>
+#include <kernel/infrastructure/i686/caches.h>
 
-#include <kernel/infrastructure/i686/types.h>
+/** Enable caches */
+void enable_caches(void) {
+    set_cr0(get_cr0() & ~(X86_CR0_CD | X86_CR0_NW));
+}
 
-void cli(void);
+/** Disable caches */
+void disable_caches(void) {
+    set_cr0((get_cr0() | X86_CR0_CD) & ~X86_CR0_NW);
 
-void sti(void);
+    invalidate_caches();
+}
 
-void hlt(void);
+/** Invalidate caches */
+void invalidate_caches(void) {
+    wbinvd();
+}
 
-void invlpg(void *vaddr);
+/** Invalidate all TLB entries including global ones */
+void invalidate_all_tlb(void) {
+    int orig_value = get_cr4();
 
-void lgdt(pseudo_descriptor_t *gdt_info);
+    /* Disable global pages if enabled. */
+    set_cr4(orig_value & ~X86_CR4_PGE);
 
-void lidt(pseudo_descriptor_t *idt_info);
+    /* Reload CR3 to invalidate the TLBs. */
+    set_cr3(get_cr3());
 
-void ltr(seg_selector_t sel);
-
-uint64_t rdmsr(uint32_t addr);
-
-void wrmsr(uint32_t addr, uint64_t val);
-
-void sfence(void);
-
-void wbinvd(void);
-
-#endif
+    set_cr4(orig_value);
+}

--- a/kernel/infrastructure/i686/cpuinfo.c
+++ b/kernel/infrastructure/i686/cpuinfo.c
@@ -302,6 +302,10 @@ static void enumerate_features(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs)
         cpuinfo->features |= CPU_FEATURE_PAT;
     }
 
+    if(flags & CPUID_FEATURE_SSE) {
+        cpuinfo->features |= CPU_FEATURE_SSE;
+    }
+
     detect_sysenter_instruction(cpuinfo, leafs);
 
     detect_syscall_instruction(cpuinfo, leafs);
@@ -496,7 +500,7 @@ static void identify_maxphyaddr(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs
  */
 static void dump_features(const cpuinfo_t *cpuinfo) {
     info(
-        "  Features:%s%s%s%s%s%s%s%s%s",
+        "  Features:%s%s%s%s%s%s%s%s%s%s",
         (cpuinfo->features == 0) ? " (none)" : "",
         (cpuinfo->features & CPU_FEATURE_APIC) ? " apic" : "",
         (cpuinfo->features & CPU_FEATURE_CPUID) ? " cpuid" : "",
@@ -504,6 +508,7 @@ static void dump_features(const cpuinfo_t *cpuinfo) {
         (cpuinfo->features & CPU_FEATURE_PAE) ? " pae" : "",
         (cpuinfo->features & CPU_FEATURE_PAT) ? " pat" : "",
         (cpuinfo->features & CPU_FEATURE_PGE) ? " pge" : "",
+        (cpuinfo->features & CPU_FEATURE_SSE) ? " sse" : "",
         (cpuinfo->features & CPU_FEATURE_SYSCALL) ? " syscall" : "",
         (cpuinfo->features & CPU_FEATURE_SYSENTER) ? " sysenter" : ""
     );

--- a/kernel/infrastructure/i686/cpuinfo.c
+++ b/kernel/infrastructure/i686/cpuinfo.c
@@ -298,10 +298,6 @@ static void enumerate_features(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs)
         cpuinfo->features |= CPU_FEATURE_PGE;
     }
 
-    if(flags & CPUID_FEATURE_MTRR) {
-        cpuinfo->features |= CPU_FEATURE_MTRR;
-    }
-
     if(flags & CPUID_FEATURE_PAT) {
         cpuinfo->features |= CPU_FEATURE_PAT;
     }
@@ -500,11 +496,10 @@ static void identify_maxphyaddr(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs
  */
 static void dump_features(const cpuinfo_t *cpuinfo) {
     info(
-        "  Features:%s%s%s%s%s%s%s%s%s%s",
+        "  Features:%s%s%s%s%s%s%s%s%s",
         (cpuinfo->features == 0) ? " (none)" : "",
         (cpuinfo->features & CPU_FEATURE_APIC) ? " apic" : "",
         (cpuinfo->features & CPU_FEATURE_CPUID) ? " cpuid" : "",
-        (cpuinfo->features & CPU_FEATURE_MTRR) ? " mtrr" : "",
         (cpuinfo->features & CPU_FEATURE_NX) ? " nx" : "",
         (cpuinfo->features & CPU_FEATURE_PAE) ? " pae" : "",
         (cpuinfo->features & CPU_FEATURE_PAT) ? " pat" : "",

--- a/kernel/infrastructure/i686/cpuinfo.c
+++ b/kernel/infrastructure/i686/cpuinfo.c
@@ -298,6 +298,14 @@ static void enumerate_features(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs)
         cpuinfo->features |= CPU_FEATURE_PGE;
     }
 
+    if(flags & CPUID_FEATURE_MTRR) {
+        cpuinfo->features |= CPU_FEATURE_MTRR;
+    }
+
+    if(flags & CPUID_FEATURE_PAT) {
+        cpuinfo->features |= CPU_FEATURE_PAT;
+    }
+
     detect_sysenter_instruction(cpuinfo, leafs);
 
     detect_syscall_instruction(cpuinfo, leafs);
@@ -492,12 +500,14 @@ static void identify_maxphyaddr(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs
  */
 static void dump_features(const cpuinfo_t *cpuinfo) {
     info(
-        "  Features:%s%s%s%s%s%s%s%s",
+        "  Features:%s%s%s%s%s%s%s%s%s%s",
         (cpuinfo->features == 0) ? " (none)" : "",
         (cpuinfo->features & CPU_FEATURE_APIC) ? " apic" : "",
         (cpuinfo->features & CPU_FEATURE_CPUID) ? " cpuid" : "",
+        (cpuinfo->features & CPU_FEATURE_MTRR) ? " mtrr" : "",
         (cpuinfo->features & CPU_FEATURE_NX) ? " nx" : "",
         (cpuinfo->features & CPU_FEATURE_PAE) ? " pae" : "",
+        (cpuinfo->features & CPU_FEATURE_PAT) ? " pat" : "",
         (cpuinfo->features & CPU_FEATURE_PGE) ? " pge" : "",
         (cpuinfo->features & CPU_FEATURE_SYSCALL) ? " syscall" : "",
         (cpuinfo->features & CPU_FEATURE_SYSENTER) ? " sysenter" : ""

--- a/kernel/infrastructure/i686/drivers/lapic.c
+++ b/kernel/infrastructure/i686/drivers/lapic.c
@@ -81,7 +81,12 @@ static void write_register(int offset, uint32_t value) {
 static void map_registers(void) {
     paddr_t paddr = platform_get_local_apic_address();
 
-    mmio_addr = map_in_kernel(paddr, APIC_REGS_SIZE, JINUE_PROT_READ | JINUE_PROT_WRITE);
+    mmio_addr = map_in_kernel(
+        paddr,
+        APIC_REGS_SIZE,
+        JINUE_PROT_READ | JINUE_PROT_WRITE,
+        JINUE_MAP_UNCACHEABLE
+    );
 
     machine_add_reserved_to_address_map(paddr, APIC_REGS_SIZE);
 

--- a/kernel/infrastructure/i686/drivers/lapic.c
+++ b/kernel/infrastructure/i686/drivers/lapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Philippe Aubertin.
+ * Copyright (C) 2025-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -212,7 +212,7 @@ void vga_init(const config_t *config) {
         VGA_TEXT_VID_BASE,
         VGA_TEXT_VID_TOP - VGA_TEXT_VID_BASE,
         JINUE_PROT_READ | JINUE_PROT_WRITE,
-        JINUE_MAP_NONE
+        JINUE_MAP_UNCACHEABLE
     );
 
     initialize_console(&console, VGA_WIDTH, VGA_LINES, do_write, do_scroll);

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -211,7 +211,8 @@ void vga_init(const config_t *config) {
     video_base_addr = map_in_kernel(
         VGA_TEXT_VID_BASE,
         VGA_TEXT_VID_TOP - VGA_TEXT_VID_BASE,
-        JINUE_PROT_READ | JINUE_PROT_WRITE
+        JINUE_PROT_READ | JINUE_PROT_WRITE,
+        JINUE_MAP_NONE
     );
 
     initialize_console(&console, VGA_WIDTH, VGA_LINES, do_write, do_scroll);

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -221,6 +221,7 @@ static void refresh_framebuffer(void) {
         (console.height - top_rows) * FONT_HEIGHT * fb.pitch
     );
 
+    /* TODO need to check support. May also need to enable SSE stuff? */
     sfence();
 }
 

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -219,6 +219,8 @@ static void refresh_framebuffer(void) {
         &fb.backbuffer[row(0)],
         (console.height - top_rows) * FONT_HEIGHT * fb.pitch
     );
+
+    /* TODO add fence */
 }
 
 /** Character write console callback function

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -341,7 +341,8 @@ void init_video_framebuffer(
     fb.framebuffer = map_in_kernel(
         bootinfo->video_fb_addr,
         bootinfo->video_fb_size,
-        JINUE_PROT_READ | JINUE_PROT_WRITE
+        JINUE_PROT_READ | JINUE_PROT_WRITE,
+        JINUE_MAP_WRITE_COMBINE
     ); 
 
     initialize_console(

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -37,8 +37,8 @@
 #include <kernel/infrastructure/i686/drivers/console.h>
 #include <kernel/infrastructure/i686/drivers/videofb.h>
 #include <kernel/infrastructure/i686/drivers/videofbfont.h>
-#include <kernel/infrastructure/i686/isa/instrs.h>
 #include <kernel/infrastructure/i686/pmap/pmap.h>
+#include <kernel/infrastructure/i686/barriers.h>
 #include <kernel/infrastructure/i686/boot_alloc.h>
 #include <kernel/infrastructure/i686/platform.h>
 #include <kernel/interface/i686/bootinfo.h>
@@ -221,8 +221,7 @@ static void refresh_framebuffer(void) {
         (console.height - top_rows) * FONT_HEIGHT * fb.pitch
     );
 
-    /* TODO need to check support. May also need to enable SSE stuff? */
-    sfence();
+    store_barrier();
 }
 
 /** Character write console callback function

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -37,6 +37,7 @@
 #include <kernel/infrastructure/i686/drivers/console.h>
 #include <kernel/infrastructure/i686/drivers/videofb.h>
 #include <kernel/infrastructure/i686/drivers/videofbfont.h>
+#include <kernel/infrastructure/i686/isa/instrs.h>
 #include <kernel/infrastructure/i686/pmap/pmap.h>
 #include <kernel/infrastructure/i686/boot_alloc.h>
 #include <kernel/infrastructure/i686/platform.h>
@@ -220,7 +221,7 @@ static void refresh_framebuffer(void) {
         (console.height - top_rows) * FONT_HEIGHT * fb.pitch
     );
 
-    /* TODO add fence */
+    sfence();
 }
 
 /** Character write console callback function

--- a/kernel/infrastructure/i686/firmware/mp.c
+++ b/kernel/infrastructure/i686/firmware/mp.c
@@ -193,7 +193,8 @@ static const mp_ptr_struct_t *map_pointer_structure(uint32_t paddr) {
     return map_in_kernel(
         paddr,
         sizeof(mp_ptr_struct_t),
-        JINUE_PROT_READ
+        JINUE_PROT_READ,
+        JINUE_MAP_NONE
     );
 }
 
@@ -210,7 +211,8 @@ static const mp_conf_table_t *map_configuration_table(const mp_ptr_struct_t *ptr
     const mp_conf_table_t *table = map_in_kernel(
         ptrst->addr,
         sizeof(mp_conf_table_t),
-        JINUE_PROT_READ
+        JINUE_PROT_READ,
+        JINUE_MAP_NONE
     );
 
     if(! validate_configuration_table_header(table)) {

--- a/kernel/infrastructure/i686/firmware/mp.c
+++ b/kernel/infrastructure/i686/firmware/mp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Philippe Aubertin.
+ * Copyright (C) 2025-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/infrastructure/i686/init.c
+++ b/kernel/infrastructure/i686/init.c
@@ -254,13 +254,13 @@ boot_alloc_t boot_alloc;
 
 /**
  * Machine-specific initialization for logging
- * 
+ *
  * Initializes the UART and VGA for logging.
- * 
+ *
  * Only the minimal initialization to support logging should be done here.
  * Furthermore, functions called here should refrain from panicking when
  * avoidable and defer the panic where possible.
- * 
+ *
  * @param config kernel configuration
  */
 void machine_init_logging(const config_t *config) {
@@ -279,12 +279,16 @@ void machine_init_logging(const config_t *config) {
     detect_cpu_features(bootinfo);
 
     /* This needs to be called before calling vga_init() and find_acpi_rsdp()
-     * because these functions need to map memory in the mapping area. */
+     * because these functions need to map memory in the mapping area.
+     *
+     * We also need it to be called before init_video_framebuffer() because we
+     * want the Page Attribute Table (PAT) to be set up so the framebuffer can
+     * be mapped with write combining (WC) memory type. */
     pmap_init(bootinfo);
 
     /* Map the first megabyte of memory temporarily so we can scan it for ACPI
      * and MultiProcessor Specification data structures. */
-    void *first1mb = map_in_kernel(0, 1 * MB, JINUE_PROT_READ);
+    void *first1mb = map_in_kernel(0, 1 * MB, JINUE_PROT_READ, JINUE_MAP_NONE);
 
     find_acpi_rsdp(first1mb);
 
@@ -310,7 +314,7 @@ void machine_init_logging(const config_t *config) {
 
 /**
  * Machine-specific initialization
- * 
+ *
  * @param config kernel configuration
  */
 void machine_init(const config_t *config) {

--- a/kernel/infrastructure/i686/isa/instrs.asm
+++ b/kernel/infrastructure/i686/isa/instrs.asm
@@ -1,4 +1,4 @@
-; Copyright (C) 2019-2024 Philippe Aubertin.
+; Copyright (C) 2019-2026 Philippe Aubertin.
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -130,5 +130,15 @@ wrmsr:
     mov edx, [esp+12]   ; Second param: val (high dword)
     
     wrmsr
+    ret
+.end:
+
+; ------------------------------------------------------------------------------
+; FUNCTION: sfence
+; C PROTOTYPE: void sfence(void)
+; ------------------------------------------------------------------------------
+    global sfence:function (sfence.end - sfence)
+sfence:
+    sfence
     ret
 .end:

--- a/kernel/infrastructure/i686/isa/instrs.asm
+++ b/kernel/infrastructure/i686/isa/instrs.asm
@@ -144,6 +144,16 @@ sfence:
 .end:
 
 ; ------------------------------------------------------------------------------
+; FUNCTION: sfence_fallback
+; C PROTOTYPE: void sfence_fallback(void)
+; ------------------------------------------------------------------------------
+    global sfence_fallback:function (sfence_fallback.end - sfence_fallback)
+sfence_fallback:
+    lock add dword [esp], 0
+    ret
+.end:
+
+; ------------------------------------------------------------------------------
 ; FUNCTION: wbinvd
 ; C PROTOTYPE: void wbinvd(void)
 ; ------------------------------------------------------------------------------

--- a/kernel/infrastructure/i686/isa/instrs.asm
+++ b/kernel/infrastructure/i686/isa/instrs.asm
@@ -142,3 +142,13 @@ sfence:
     sfence
     ret
 .end:
+
+; ------------------------------------------------------------------------------
+; FUNCTION: wbinvd
+; C PROTOTYPE: void wbinvd(void)
+; ------------------------------------------------------------------------------
+    global wbinvd:function (wbinvd.end - wbinvd)
+wbinvd:
+    wbinvd
+    ret
+.end:

--- a/kernel/infrastructure/i686/pmap/nopae.c
+++ b/kernel/infrastructure/i686/pmap/nopae.c
@@ -109,7 +109,7 @@ pte_t *nopae_get_pte_with_offset(pte_t *pte, unsigned int offset) {
  * (specifically, the No-eXecute/NX bit).
  *
  * The appropriate flags for this function are the architecture-dependent flags,
- * i.e. those defined by the X86_PTE_... constants. See map_page_access_flags()
+ * i.e. those defined by the X86_PTE_... constants. See map_arch_page_flags()
  * for additional context.
  *
  * @param pte page table or page directory entry
@@ -126,7 +126,7 @@ static uint32_t filter_pte_flags(uint64_t flags) {
  * Set page frame address and flags of the specified page table/directory entry
  *
  * The appropriate flags for this function are the architecture-dependent flags,
- * i.e. those defined by the X86_PTE_... constants. See map_page_access_flags()
+ * i.e. those defined by the X86_PTE_... constants. See map_arch_page_flags()
  * for additional context.
  *
  * @param pte page table or page directory entry

--- a/kernel/infrastructure/i686/pmap/pae.c
+++ b/kernel/infrastructure/i686/pmap/pae.c
@@ -174,13 +174,13 @@ pte_t *pae_lookup_page_directory(
         addr_space_t    *addr_space,
         const void      *addr,
         bool             create_as_needed,
-        bool            *reload_cr3) {
+        bool            *must_reload_cr3) {
 
     /** ASSERTION: addr_space must not be NULL */
     assert(addr_space != NULL);
 
-    /** ASSERTION: reload_cr3 can only be NULL if create_as_needed is false */
-    assert(reload_cr3 != NULL || !create_as_needed);
+    /** ASSERTION: must_reload_cr3 can only be NULL if create_as_needed is false */
+    assert(must_reload_cr3 != NULL || !create_as_needed);
 
     pdpt_t *pdpt    = addr_space->top_level.pdpt;
     pte_t  *pdpte   = &pdpt->pd[pdpt_offset_of(addr)];
@@ -206,7 +206,7 @@ pte_t *pae_lookup_page_directory(
         /* In 32-bit PAE mode, the CPU stores the four entries of the PDPT
          * in registers. Whenever we modify an entry in the PDPT, we must
          * reload CR3. */
-        *reload_cr3 = true;
+        *must_reload_cr3 = true;
     }
 
     return page_directory;

--- a/kernel/infrastructure/i686/pmap/pae.c
+++ b/kernel/infrastructure/i686/pmap/pae.c
@@ -247,7 +247,7 @@ pte_t *pae_get_pte_with_offset(pte_t *pte, unsigned int offset) {
  * Set page frame address and flags of the specified page table/directory entry
  *
  * The appropriate flags for this function are the architecture-dependent flags,
- * i.e. those defined by the X86_PTE_... constants. See map_page_access_flags()
+ * i.e. those defined by the X86_PTE_... constants. See map_arch_page_flags()
  * for additional context.
  *
  * @param pte page table or page directory entry

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -37,6 +37,8 @@
 #include <kernel/domain/entities/object.h>
 #include <kernel/domain/entities/process.h>
 #include <kernel/domain/services/panic.h>
+#include <kernel/infrastructure/i686/asm/msr.h>
+#include <kernel/infrastructure/i686/asm/pat.h>
 #include <kernel/infrastructure/i686/isa/instrs.h>
 #include <kernel/infrastructure/i686/isa/regs.h>
 #include <kernel/infrastructure/i686/memory/pages.h>
@@ -187,7 +189,7 @@ void copy_ptes(pte_t *dest, const pte_t *src, int n) {
  * Set page frame address and flags of the specified page table/directory entry
  *
  * The appropriate flags for this function are the architecture-dependent flags,
- * i.e. those defined by the X86_PTE_... constants. See map_page_access_flags()
+ * i.e. those defined by the X86_PTE_... constants. See map_arch_page_flags()
  * for additional context.
  *
  * @param pte page table or page directory entry
@@ -272,6 +274,37 @@ void pmap_init(const bootinfo_t *bootinfo) {
     /* Enable global pages */
     if(cpu_has_feature(CPU_FEATURE_PGE)) {
         set_cr4(get_cr4() | X86_CR4_PGE);
+    }
+
+    if(cpu_has_feature(CPU_FEATURE_PAT)) {
+        /* Intel has two different erratas for PAT on specific CPU models where
+         * the CPU might be confused about whether it should look at the upper
+         * or lower four entries of the PAT.
+         * 
+         * See:
+         *  - Intel Pentium III Processor Specification Update (Document number
+         *    244453-058, August 2007) Section "E27. Upper Four PAT Entries
+         *    Not Usable With Mode B or Mode C Paging" page 53.
+         *  - Intel Pentium 4 Processor Specification Update (Document number
+         *    249199-057, December 2004) Section "N46. PAT Index MSB May Be
+         *    Calculated Incorrectly" page 44.
+         * 
+         * For this reason, let's only use the lower four entries and repeat
+         * them in the upper four. For the lower four entries, we use the reset
+         * values except we replace slot 1 from WT we don't need to WC we do
+         * need. */
+        uint64_t patval =
+            /* lower four */
+            ((uint64_t)PAT_WB << PAT0)  |
+            ((uint64_t)PAT_WC << PAT1)  |
+            ((uint64_t)PAT_UC_MINUS << PAT2) |
+            ((uint64_t)PAT_UC << PAT3) |
+            /* upper four */
+            ((uint64_t)PAT_WB << PAT4)  |
+            ((uint64_t)PAT_WC << PAT5)  |
+            ((uint64_t)PAT_UC_MINUS << PAT6) |
+            ((uint64_t)PAT_UC << PAT7);
+        wrmsr(MSR_IA32_PAT, patval);
     }
 }
 
@@ -496,18 +529,22 @@ static pte_t *lookup_userspace_page_table(
 }
 
 /**
- * Translate architecture-independent protection flags to architecture-dependent flags
+ * Translate architecture-independent flags to architecture-dependent flags
  *
- * Argument should be either JINUE_PROT_NONE (no access) or any combination of
- * JINUE_PROT_READ, JINUE_PROT_WRITE and/or JINUE_PROT_EXEC.
+ * Argument prot should be either JINUE_PROT_NONE (no access) or any
+ * combination of JINUE_PROT_READ, JINUE_PROT_WRITE and/or JINUE_PROT_EXEC.
+ * 
+ * Argument flags should be JINUE_MAP_NONE or a combination of the JINUE_MAP_xx
+ * flags.
  *
  * Return value is a combination of architecture-dependent flags appropriate to
  * be set directly in a page table entry (i.e. the X86_PTE_... constants).
  *
  * @param prot architecture-independent protection flags
+ * @param prot architecture-independent mapping flags
  * @return architecture-dependent flags
  */
-static uint64_t map_page_access_flags(int prot) {
+static uint64_t map_arch_page_flags(int prot, int flags) {
     const int rwe_mask = JINUE_PROT_READ | JINUE_PROT_WRITE | JINUE_PROT_EXEC;
 
     if(! (prot & rwe_mask)) {
@@ -524,6 +561,15 @@ static uint64_t map_page_access_flags(int prot) {
         mapped_flags |= cpu_has_feature(CPU_FEATURE_NX) ? X86_PTE_NX : 0;
     }
 
+    if(flags & JINUE_MAP_UNCACHEABLE) {
+        mapped_flags |= X86_PTE_PCD | X86_PTE_PWT;
+    }
+
+    if(flags & JINUE_MAP_WRITE_COMBINE) {
+        /* Write combining (1) if PAT supported, uncacheable (3) otherwise */
+        mapped_flags |= (cpu_has_feature(CPU_FEATURE_PAT) ? 0 : X86_PTE_PCD) | X86_PTE_PWT;
+    }
+
     return mapped_flags;
 }
 
@@ -537,8 +583,9 @@ static uint64_t map_page_access_flags(int prot) {
  * @param vaddr virtual address of mapping
  * @param paddr address of page frame
  * @param prot protections flags
+ * @param flags mapping flags
  */
-void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot) {
+void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot, int flags) {
     /** ASSERTION: we assume vaddr is aligned on a page boundary */
     assert( page_offset_of(addr) == 0 );
 
@@ -550,7 +597,7 @@ void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot) {
         set_pte(
             get_pte_with_offset(pte, PAGE_NUMBER(offset)),
             paddr + offset,
-            map_page_access_flags(prot) | X86_PTE_GLOBAL
+            map_arch_page_flags(prot, flags) | X86_PTE_GLOBAL
         );
 
         invlpg(addr + offset);
@@ -568,6 +615,7 @@ void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot) {
  * @param paddr start address in physical memory
  * @param length length of mapping
  * @param prot protection flags
+ * @param flags mapping flags
  * @return true on success, false on page table allocation error
  */
 bool machine_map_userspace(
@@ -575,7 +623,8 @@ bool machine_map_userspace(
         addr_t           addr,
         size_t           size,
         paddr_t          paddr,
-        int              prot) {
+        int              prot,
+        int              flags) {
 
     /** ASSERTION: we assume vaddr is aligned on a page boundary */
     assert( page_offset_of(addr) == 0 );
@@ -611,7 +660,7 @@ bool machine_map_userspace(
         set_pte(
             get_pte_with_offset(pte, pte_index),
             paddr + offset,
-            map_page_access_flags(prot) | X86_PTE_USER
+            map_arch_page_flags(prot, flags) | X86_PTE_USER
         );
 
         if(needs_invalidation && !reload_cr3) {

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -45,6 +45,7 @@
 #include <kernel/infrastructure/i686/pmap/pmap.h>
 #include <kernel/infrastructure/i686/pmap/private.h>
 #include <kernel/infrastructure/i686/boot_alloc.h>
+#include <kernel/infrastructure/i686/caches.h>
 #include <kernel/infrastructure/i686/cpuinfo.h>
 #include <kernel/infrastructure/i686/percpu.h>
 #include <kernel/infrastructure/elf.h>
@@ -252,6 +253,68 @@ static paddr_t get_pte_paddr(const pte_t *pte) {
     }
 }
 
+/** Reload the CR3 control register with its existing value
+ * 
+ * The register value remains unchanged but reloading CR3 it has the side
+ * effect of invalidating all non-global TLB entries.
+ */
+static void reload_cr3(void) {
+    set_cr3(get_cr3());
+}
+
+/** Initialize Page Attribute Table (PAT) */
+static void initialize_pat(void) {
+    if(!cpu_has_feature(CPU_FEATURE_PAT)) {
+        return;
+    }
+
+    /* See procedure in Intel64 and IA-32 Architectures Software Developer’s
+     * Manual Volume 3 section 13.11.8 "MTRR Considerations in MP Systems".
+     *
+     * This is the procedure described for the MTRRs but section 13.12.4
+     * "Programming the PAT" refers to it. */
+
+    disable_caches();
+
+    invalidate_all_tlb();
+
+    /* Intel has two different erratas for PAT on specific CPU models where
+     * the CPU might be confused about whether it should look at the upper
+     * or lower four entries of the PAT.
+     * 
+     * See:
+     *  - Intel Pentium III Processor Specification Update (Document number
+     *    244453-058, August 2007) Section "E27. Upper Four PAT Entries
+     *    Not Usable With Mode B or Mode C Paging" page 53.
+     *  - Intel Pentium 4 Processor Specification Update (Document number
+     *    249199-057, December 2004) Section "N46. PAT Index MSB May Be
+     *    Calculated Incorrectly" page 44.
+     * 
+     * For this reason, let's only use the lower four entries and repeat
+     * them in the upper four. For the lower four entries, we use the reset
+     * values except we replace slot 1 from WT we don't need to WC we do
+     * need. */
+    uint64_t patval =
+        /* lower four */
+        ((uint64_t)PAT_WB << PAT0)  |
+        ((uint64_t)PAT_WC << PAT1)  |
+        ((uint64_t)PAT_UC_MINUS << PAT2) |
+        ((uint64_t)PAT_UC << PAT3) |
+        /* upper four */
+        ((uint64_t)PAT_WB << PAT4)  |
+        ((uint64_t)PAT_WC << PAT5)  |
+        ((uint64_t)PAT_UC_MINUS << PAT6) |
+        ((uint64_t)PAT_UC << PAT7);
+
+    wrmsr(MSR_IA32_PAT, patval);
+
+    invalidate_caches();
+
+    invalidate_all_tlb();
+
+    enable_caches();
+}
+
 /**
  * Initialize virtual memory management
  *
@@ -271,40 +334,14 @@ void pmap_init(const bootinfo_t *bootinfo) {
     entries_per_page_table  = pgtable_format_pae ? PAE_PAGE_TABLE_PTES :  NOPAE_PAGE_TABLE_PTES;
     page_frame_number_mask  = ((UINT64_C(1) << cpu_phys_addr_width()) - 1) & (~PAGE_MASK);
 
+    /* Must be done before enabling global pages to make sure no stale entries
+     * for global pages with wrong cacheability information remain in the TLBs.
+     */
+    initialize_pat();
+
     /* Enable global pages */
     if(cpu_has_feature(CPU_FEATURE_PGE)) {
         set_cr4(get_cr4() | X86_CR4_PGE);
-    }
-
-    if(cpu_has_feature(CPU_FEATURE_PAT)) {
-        /* Intel has two different erratas for PAT on specific CPU models where
-         * the CPU might be confused about whether it should look at the upper
-         * or lower four entries of the PAT.
-         * 
-         * See:
-         *  - Intel Pentium III Processor Specification Update (Document number
-         *    244453-058, August 2007) Section "E27. Upper Four PAT Entries
-         *    Not Usable With Mode B or Mode C Paging" page 53.
-         *  - Intel Pentium 4 Processor Specification Update (Document number
-         *    249199-057, December 2004) Section "N46. PAT Index MSB May Be
-         *    Calculated Incorrectly" page 44.
-         * 
-         * For this reason, let's only use the lower four entries and repeat
-         * them in the upper four. For the lower four entries, we use the reset
-         * values except we replace slot 1 from WT we don't need to WC we do
-         * need. */
-        uint64_t patval =
-            /* lower four */
-            ((uint64_t)PAT_WB << PAT0)  |
-            ((uint64_t)PAT_WC << PAT1)  |
-            ((uint64_t)PAT_UC_MINUS << PAT2) |
-            ((uint64_t)PAT_UC << PAT3) |
-            /* upper four */
-            ((uint64_t)PAT_WB << PAT4)  |
-            ((uint64_t)PAT_WC << PAT5)  |
-            ((uint64_t)PAT_UC_MINUS << PAT6) |
-            ((uint64_t)PAT_UC << PAT7);
-        wrmsr(MSR_IA32_PAT, patval);
     }
 }
 
@@ -451,24 +488,24 @@ static pte_t *lookup_kernel_page_table_entry(const void *addr) {
  * currently no page table entry for the specified address and address space.
  *
  * If a new page table is allocated (when create_as_needed is true), CR3 may
- * need to be reloaded. If it's the case, the boolean pointed to by reload_cr3
- * is set to true. Initially setting this boolean to false is the caller's
- * responsibility.
+ * need to be reloaded. If it's the case, the boolean pointed to by
+ * must_reload_cr3 is set to true. Initially setting this boolean to false is
+ * the caller's responsibility.
  *
- * reload_cr3 must not be NULL if create_as_needed is true but is ignored and
- * can be set to NULL if create_as_needed is false.
+ * must_reload_cr3 must not be NULL if create_as_needed is true but is ignored
+ * and can be set to NULL if create_as_needed is false.
  *
  * @param addr_space address space in which the address is looked up.
  * @param addr userspace address to look up
  * @param create_as_needed whether a page table is allocated if it does not exist
- * @param reload_cr3 (out) set to true if CR3 needs to be reloaded
+ * @param must_reload_cr3 (out) set to true if CR3 needs to be reloaded
  * @return pointer to page table on success, NULL otherwise
  */
 static pte_t *lookup_userspace_page_table(
         addr_space_t    *addr_space,
         const void      *addr,
         bool             create_as_needed,
-        bool            *reload_cr3) {
+        bool            *must_reload_cr3) {
 
     pte_t *page_directory;
 
@@ -486,7 +523,7 @@ static pte_t *lookup_userspace_page_table(
             addr_space,
             addr,
             create_as_needed,
-            reload_cr3
+            must_reload_cr3
         );
     }
     else {
@@ -634,8 +671,8 @@ bool machine_map_userspace(
 
     int pte_index   = page_table_offset_of(addr);
 
-    bool reload_cr3 = false;
-    pte_t *pte      = lookup_userspace_page_table(addr_space, addr, true, &reload_cr3);
+    bool must_reload_cr3 = false;
+    pte_t *pte      = lookup_userspace_page_table(addr_space, addr, true, &must_reload_cr3);
 
     if(pte == NULL) {
         return false;
@@ -647,7 +684,7 @@ bool machine_map_userspace(
                 addr_space,
                 addr + offset,
                 true,
-                &reload_cr3
+                &must_reload_cr3
             );
 
             if(pte == NULL) {
@@ -663,15 +700,15 @@ bool machine_map_userspace(
             map_arch_page_flags(prot, flags) | X86_PTE_USER
         );
 
-        if(needs_invalidation && !reload_cr3) {
+        if(needs_invalidation && !must_reload_cr3) {
             invlpg(addr + offset);
         }
 
         ++pte_index;
     }
 
-    if(needs_invalidation && reload_cr3) {
-        set_cr3(get_cr3());
+    if(needs_invalidation && must_reload_cr3) {
+        reload_cr3();
     }
 
     return true;

--- a/kernel/interface/syscalls.c
+++ b/kernel/interface/syscalls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -49,6 +49,9 @@
 
 #define WRITE_EXEC      (JINUE_PROT_WRITE | JINUE_PROT_EXEC)
 
+#define ALL_MAP_FLAGS   (JINUE_MAP_UNCACHEABLE | JINUE_MAP_WRITE_COMBINE)
+
+#define UC_WC           (JINUE_MAP_UNCACHEABLE | JINUE_MAP_WRITE_COMBINE)
 
 static void set_return_value(jinue_syscall_args_t *args, int retval) {
     args->arg0  = (uintptr_t)retval;
@@ -356,6 +359,16 @@ static void sys_mmap(jinue_syscall_args_t *args) {
     }
 
     if((mmap_args.prot & WRITE_EXEC) == WRITE_EXEC) {
+        set_error(args, JINUE_ENOTSUP);
+        return;
+    }
+
+    if((mmap_args.flags & ~ALL_MAP_FLAGS) != 0) {
+        set_error(args, JINUE_EINVAL);
+        return;
+    }
+
+    if((mmap_args.flags & UC_WC) == UC_WC) {
         set_error(args, JINUE_ENOTSUP);
         return;
     }

--- a/userspace/lib/jinue/syscalls.c
+++ b/userspace/lib/jinue/syscalls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Philippe Aubertin.
+ * Copyright (C) 2019-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -137,6 +137,7 @@ int jinue_mmap(
         void        *addr,
         size_t       length,
         int          prot,
+        int          flags,
         uint64_t     paddr,
         int         *perrno) {
 
@@ -146,6 +147,7 @@ int jinue_mmap(
     mmap_args.addr = addr;
     mmap_args.length = length;
     mmap_args.prot = prot;
+    mmap_args.flags = flags;
     mmap_args.paddr = paddr;
 
     args.arg0 = JINUE_SYS_MMAP;

--- a/userspace/lib/libc/brk.c
+++ b/userspace/lib/libc/brk.c
@@ -126,6 +126,7 @@ int __brk_perrno(void *addr, int *perrno) {
                 allocated_break,
                 size,
                 JINUE_PROT_READ | JINUE_PROT_WRITE,
+                JINUE_MAP_NONE,
                 physaddr,
                 perrno);
 

--- a/userspace/lib/libc/brk.c
+++ b/userspace/lib/libc/brk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Philippe Aubertin.
+ * Copyright (C) 2023-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/lib/libc/mmap.c
+++ b/userspace/lib/libc/mmap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Philippe Aubertin.
+ * Copyright (C) 2023-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/lib/libc/mmap.c
+++ b/userspace/lib/libc/mmap.c
@@ -62,7 +62,12 @@ void *__mmap_perrno(
         return MAP_FAILED;
     }
 
-    const int flags_mask = MAP_FIXED | MAP_SHARED | MAP_ANONYMOUS;
+    const int flags_mask =
+          MAP_FIXED
+        | MAP_SHARED
+        | MAP_ANONYMOUS
+        | MAP_UNCACHEABLE
+        | MAP_WRITE_COMBINE;
 
     if((flags & ~flags_mask) != 0) {
         *perrno = EINVAL;
@@ -79,6 +84,13 @@ void *__mmap_perrno(
     const int write_exec = PROT_WRITE | PROT_EXEC;
 
     if((prot & write_exec) == write_exec) {
+        *perrno = ENOTSUP;
+        return MAP_FAILED;
+    }
+
+    const int uc_wc = MAP_UNCACHEABLE | MAP_WRITE_COMBINE;
+
+    if((flags & uc_wc) == uc_wc) {
         *perrno = ENOTSUP;
         return MAP_FAILED;
     }
@@ -129,7 +141,17 @@ void *__mmap_perrno(
         paddr = off;
     }
 
-    int ret = jinue_mmap(JINUE_DESC_SELF_PROCESS, addr, aligned_length, prot, paddr, perrno);
+    const int syscall_flags_mask = MAP_UNCACHEABLE | MAP_WRITE_COMBINE;
+
+    int ret = jinue_mmap(
+        JINUE_DESC_SELF_PROCESS,
+        addr,
+        aligned_length,
+        prot,
+        flags & syscall_flags_mask,
+        paddr,
+        perrno
+    );
 
     if(ret < 0) {
         return MAP_FAILED;

--- a/userspace/loader/binfmt/elf.c
+++ b/userspace/loader/binfmt/elf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Philippe Aubertin.
+ * Copyright (C) 2023-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/loader/binfmt/elf.c
+++ b/userspace/loader/binfmt/elf.c
@@ -185,7 +185,7 @@ static void *get_at_phdr(const Elf32_Ehdr *ehdr) {
  * @return start of stack in loader address space
  *
  * */
-static int map_flags(Elf32_Word p_flags) {
+static int map_protection_flags(Elf32_Word p_flags) {
     /* set flags */
     int flags = 0;
 
@@ -246,14 +246,14 @@ static int load_segments(elf_info_t *elf_info, const file_t *exec_file) {
                 memsize,
                 exec_file->segment_index,
                 phdr->p_offset - diff,
-                map_flags(phdr->p_flags)
+                map_protection_flags(phdr->p_flags)
             );
 
             if(status < 0) {
                 return EXIT_FAILURE;
             }
         } else {
-            char *segment = map_anonymous((void *)vaddr, memsize, map_flags(phdr->p_flags));
+            char *segment = map_anonymous((void *)vaddr, memsize, map_protection_flags(phdr->p_flags));
 
             if(segment == NULL) {
                 return EXIT_FAILURE;

--- a/userspace/loader/core/mappings.c
+++ b/userspace/loader/core/mappings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Philippe Aubertin.
+ * Copyright (C) 2024-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without

--- a/userspace/loader/core/mappings.c
+++ b/userspace/loader/core/mappings.c
@@ -45,7 +45,15 @@ int map_file(void *vaddr, size_t size, int segment_index, size_t offset, int per
     uint64_t file_start = get_meminfo_segment_start(segment_index);
     uint64_t paddr      = file_start + offset;
 
-    int status = jinue_mmap(INIT_PROCESS_DESCRIPTOR, vaddr, size, perms, paddr, &errno);
+    int status = jinue_mmap(
+        INIT_PROCESS_DESCRIPTOR,
+        vaddr,
+        size,
+        perms,
+        JINUE_MAP_NONE,
+        paddr,
+        &errno
+    );
 
     if(status < 0) {
         jinue_error("error: jinue_mmap() failed: %s", strerror(errno));
@@ -69,7 +77,15 @@ void *map_anonymous(void *vaddr, size_t size, int perms) {
     }
 
     /* Map into the target process. */
-    int status = jinue_mmap(INIT_PROCESS_DESCRIPTOR, vaddr, size, perms, paddr, &errno);
+    int status = jinue_mmap(
+        INIT_PROCESS_DESCRIPTOR,
+        vaddr,
+        size,
+        perms,
+        JINUE_MAP_NONE,
+        paddr,
+        &errno
+    );
 
     if(status < 0) {
         jinue_error("error: jinue_mmap() failed: %s", strerror(errno));


### PR DESCRIPTION
Use Page Attribute Table (PAT) to map video framebuffer with write combining memory type for performance.