### PR TITLE
Large pages support for kernel mapping

### DIFF
--- a/include/jinue/shared/asm/mman.h
+++ b/include/jinue/shared/asm/mman.h
@@ -53,4 +53,7 @@
 /** map as write-combining memory */
 #define JINUE_MAP_WRITE_COMBINE (1<<1)
 
+/** map with large pages */
+#define JINUE_MAP_LARGE_PAGES   (1<<2)
+
 #endif

--- a/include/kernel/infrastructure/i686/asm/cpuid.h
+++ b/include/kernel/infrastructure/i686/asm/cpuid.h
@@ -73,6 +73,8 @@
 
 #define CPUID_FEATURE_FPU               (1<<0)
 
+#define CPUID_FEATURE_PSE               (1<<3)
+
 #define CPUID_FEATURE_PAE               (1<<6)
 
 #define CPUID_FEATURE_APIC              (1<<9)

--- a/include/kernel/infrastructure/i686/asm/cpuinfo.h
+++ b/include/kernel/infrastructure/i686/asm/cpuinfo.h
@@ -46,11 +46,13 @@
 
 #define CPU_FEATURE_PGE         (1<<5)
 
-#define CPU_FEATURE_SSE         (1<<6)
+#define CPU_FEATURE_PSE         (1<<6)
 
-#define CPU_FEATURE_SYSCALL     (1<<7)
+#define CPU_FEATURE_SSE         (1<<7)
 
-#define CPU_FEATURE_SYSENTER    (1<<8)
+#define CPU_FEATURE_SYSCALL     (1<<8)
+
+#define CPU_FEATURE_SYSENTER    (1<<9)
 
 /* vendors */
 

--- a/include/kernel/infrastructure/i686/asm/x86.h
+++ b/include/kernel/infrastructure/i686/asm/x86.h
@@ -82,7 +82,7 @@
 /** page was written to */
 #define X86_PTE_DIRTY               (1<< 6)
 
-/** page directory entry describes a 4M page */
+/** page directory entry describes a 2MB or 4MB page */
 #define X86_PDE_PAGE_SIZE           (1<< 7)
 
 /** page is global (mapped in every address space) */

--- a/include/kernel/infrastructure/i686/exports/asm/machine.h
+++ b/include/kernel/infrastructure/i686/exports/asm/machine.h
@@ -34,8 +34,12 @@
 
 #include <kernel/utils/asm/utils.h>
 
-#define MAPPING_AREA_ADDR   0xfc000000
+#define MAPPING_AREA_ADDR       0xec000000
 
-#define MAPPING_AREA_SIZE   (64 * MB)
+#define MAPPING_AREA_SIZE       (64 * MB)
+
+#define HUGE_PAGES_AREA_ADDR    0xf0000000
+
+#define HUGE_PAGES_AREA_SIZE    (256 * MB)
 
 #endif

--- a/include/kernel/infrastructure/i686/exports/asm/machine.h
+++ b/include/kernel/infrastructure/i686/exports/asm/machine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Philippe Aubertin.
+ * Copyright (C) 2025-2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -38,8 +38,8 @@
 
 #define MAPPING_AREA_SIZE       (64 * MB)
 
-#define HUGE_PAGES_AREA_ADDR    0xf0000000
+#define LARGE_PAGES_AREA_ADDR   0xf0000000
 
-#define HUGE_PAGES_AREA_SIZE    (256 * MB)
+#define LARGE_PAGES_AREA_SIZE   (256 * MB)
 
 #endif

--- a/include/kernel/infrastructure/i686/exports/asm/machine.h
+++ b/include/kernel/infrastructure/i686/exports/asm/machine.h
@@ -34,12 +34,16 @@
 
 #include <kernel/utils/asm/utils.h>
 
-#define MAPPING_AREA_ADDR       0xec000000
+/* This region is currently only used to map the video framebuffer and its
+ * back buffer. We reserve 128MB each to support 8K resolutions, plus a bit
+ * more to have some margin in case they aren't aligned on a large page
+ * boundary. */
+#define LARGE_PAGES_AREA_SIZE   (272 * MB)
+
+#define LARGE_PAGES_AREA_ADDR   0xef000000
 
 #define MAPPING_AREA_SIZE       (64 * MB)
 
-#define LARGE_PAGES_AREA_ADDR   0xf0000000
-
-#define LARGE_PAGES_AREA_SIZE   (256 * MB)
+#define MAPPING_AREA_ADDR       (LARGE_PAGES_AREA_ADDR - MAPPING_AREA_SIZE)
 
 #endif

--- a/include/kernel/infrastructure/i686/pmap/private.h
+++ b/include/kernel/infrastructure/i686/pmap/private.h
@@ -55,11 +55,7 @@
 /** page directory entry offset of virtual (linear address) */
 #define PAGE_DIRECTORY_OFFSET_OF(x) ( ((uintptr_t)(x) / (PAGE_SIZE * PAGE_TABLE_ENTRIES)) & PAGE_TABLE_MASK )
 
-extern pte_t *kernel_page_tables;
-
 extern size_t entries_per_page_table;
-
-extern bool pgtable_format_pae;
 
 extern uint64_t page_frame_number_mask;
 

--- a/include/kernel/interface/i686/asm/bootinfo.h
+++ b/include/kernel/interface/i686/asm/bootinfo.h
@@ -34,9 +34,11 @@
 
 #define BOOTINFO_FEATURE_CPUID  (1<<0)
 
-#define BOOTINFO_FEATURE_PAE    (1<<1)
+#define BOOTINFO_FEATURE_NX     (1<<1)
 
-#define BOOTINFO_FEATURE_NX     (1<<2)
+#define BOOTINFO_FEATURE_PAE    (1<<2)
+
+#define BOOTINFO_FEATURE_PSE    (1<<3)
 
 /* The following definitions must match the offsets of the members of the
  * bootinfo_t struct defined in interface/i686/types.h. They are used by

--- a/include/kernel/interface/i686/setup/setup32.h
+++ b/include/kernel/interface/i686/setup/setup32.h
@@ -35,7 +35,7 @@
 #include <kernel/interface/i686/types.h>
 #include <stdbool.h>
 
-void enable_paging(bool use_pae, bool use_nx, uint32_t cr3);
+void enable_paging(uint32_t cr3, int bootinfo_features);
 
 void adjust_stack(void);
 

--- a/include/kernel/machine/pmap.h
+++ b/include/kernel/machine/pmap.h
@@ -33,6 +33,7 @@
 #define JINUE_KERNEL_MACHINE_PMAP_H
 
 #include <kernel/types.h>
+#include <stddef.h>
 
 void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot, int flags);
 
@@ -47,5 +48,7 @@ bool machine_map_userspace(
         int              flags);
 
 paddr_t machine_lookup_kernel_paddr(const void *addr);
+
+size_t machine_large_page_size(void);
 
 #endif

--- a/kernel/domain/services/mman.c
+++ b/kernel/domain/services/mman.c
@@ -59,11 +59,9 @@ alloc_region_t large_pages_region = {
 
 static struct {
     alloc_region_t  *region;
-    addr_t           addr;
     const void      *latest_addr;
     int              latest_prot;
     int              latest_flags;
-    size_t           size_remaining;
 } alloc_state = {
     .region         = NULL,
     .latest_addr    = NULL,
@@ -142,7 +140,6 @@ void *map_in_kernel(paddr_t paddr, size_t size, int prot, int flags) {
     }
 
     size_t offset   = paddr & (region->page_size - 1);
-
     addr_t start    = region->addr;
     addr_t end      = ALIGN_END_PTR(start + offset + size, region->page_size);
     

--- a/kernel/domain/services/mman.c
+++ b/kernel/domain/services/mman.c
@@ -38,18 +38,37 @@
 #include <kernel/utils/utils.h>
 #include <stdbool.h>
 
-static struct {
+typedef struct {
     addr_t       addr;
-    const void  *latest_addr;
-    int          latest_prot;
-    int          latest_flags;
     size_t       size_remaining;
-} alloc_state = {
+    size_t       page_size;
+} alloc_region_t;
+
+alloc_region_t normal_region = {
     .addr           = (addr_t)MAPPING_AREA_ADDR,
+    .size_remaining = MAPPING_AREA_SIZE,
+    .page_size      = PAGE_SIZE,
+};
+
+alloc_region_t large_pages_region = {
+    .addr           = (addr_t)LARGE_PAGES_AREA_ADDR,
+    .size_remaining = LARGE_PAGES_AREA_SIZE,
+    /* set by map_in_kernel() */
+    .page_size      = 0,
+};
+
+static struct {
+    alloc_region_t  *region;
+    addr_t           addr;
+    const void      *latest_addr;
+    int              latest_prot;
+    int              latest_flags;
+    size_t           size_remaining;
+} alloc_state = {
+    .region         = NULL,
     .latest_addr    = NULL,
     .latest_prot    = JINUE_PROT_NONE,
     .latest_flags   = JINUE_MAP_NONE,
-    .size_remaining = MAPPING_AREA_SIZE,
 };
 
 /**
@@ -61,17 +80,19 @@ static struct {
  * @param flags mapping flags
  */
 static void expand_mapping(paddr_t paddr, addr_t new_end, int prot, int flags) {
-    addr_t old_end  = alloc_state.addr;
+    alloc_region_t *region = alloc_state.region;
+
+    addr_t old_end  = region->addr;
     size_t size     = new_end - old_end;
 
-    if(size > alloc_state.size_remaining) {
+    if(size > region->size_remaining) {
         panic("No more space to map memory in kernel");
     }
 
     machine_map_kernel(old_end, size, paddr, prot, flags);
 
-    alloc_state.addr            = new_end;
-    alloc_state.size_remaining  -= size;
+    region->addr            = new_end;
+    region->size_remaining  -= size;
 }
 
 /**
@@ -80,13 +101,15 @@ static void expand_mapping(paddr_t paddr, addr_t new_end, int prot, int flags) {
  * @param new_end new end of the shrunk mapping, must be page aligned
  */
 static void shrink_mapping(addr_t new_end) {
-    addr_t old_end  = alloc_state.addr;
+    alloc_region_t *region = alloc_state.region;
+
+    addr_t old_end  = region->addr;
     size_t size     = old_end - new_end;
 
     machine_unmap_kernel(new_end, size);
 
-    alloc_state.addr            = new_end;
-    alloc_state.size_remaining  += size;
+    region->addr            = new_end;
+    region->size_remaining  += size;
 }
 
 /**
@@ -108,14 +131,25 @@ static void shrink_mapping(addr_t new_end) {
  * @param flags mapping flags
  */
 void *map_in_kernel(paddr_t paddr, size_t size, int prot, int flags) {
-    size_t offset   = paddr % PAGE_SIZE;
+    alloc_region_t *region;
 
-    addr_t start    = alloc_state.addr;
-    addr_t end      = ALIGN_END_PTR(start + offset + size, PAGE_SIZE);
+    if(flags & JINUE_MAP_LARGE_PAGES) {
+        large_pages_region.page_size = machine_large_page_size();
+        region = &large_pages_region;
+    }
+    else {
+        region = &normal_region;
+    }
+
+    size_t offset   = paddr & (region->page_size - 1);
+
+    addr_t start    = region->addr;
+    addr_t end      = ALIGN_END_PTR(start + offset + size, region->page_size);
     
-    alloc_state.latest_addr = start + offset;
-    alloc_state.latest_prot = prot;
-    alloc_state.latest_flags = flags;
+    alloc_state.region          = region;
+    alloc_state.latest_addr     = start + offset;
+    alloc_state.latest_prot     = prot;
+    alloc_state.latest_flags    = flags;
 
     expand_mapping(paddr - offset, end, prot, flags);
 
@@ -128,12 +162,14 @@ void *map_in_kernel(paddr_t paddr, size_t size, int prot, int flags) {
  * @param size size of memory to map, cannot be zero
  */
 void resize_map_in_kernel(size_t size) {
+    alloc_region_t *region = alloc_state.region;
+
     const void *addr    = alloc_state.latest_addr;
 
-    addr_t old_end      = alloc_state.addr;
-    addr_t new_end      = ALIGN_END_PTR((addr_t)addr + size, PAGE_SIZE);
+    addr_t old_end      = alloc_state.region->addr;
+    addr_t new_end      = ALIGN_END_PTR((addr_t)addr + size, region->page_size);
 
-    alloc_state.addr    = new_end;
+    alloc_state.region->addr    = new_end;
 
     if(new_end <= old_end) {
         shrink_mapping(new_end);
@@ -141,7 +177,7 @@ void resize_map_in_kernel(size_t size) {
         int prot        = alloc_state.latest_prot;
         int flags       = alloc_state.latest_flags;
 
-        addr_t start    = ALIGN_START_PTR(addr, PAGE_SIZE);
+        addr_t start    = ALIGN_START_PTR(addr, region->page_size);
         paddr_t paddr   = machine_lookup_kernel_paddr(start) + (old_end - start);
 
         expand_mapping(paddr, new_end, prot, flags);
@@ -154,9 +190,11 @@ void resize_map_in_kernel(size_t size) {
  * @param addr address returned by map_in_kernel() for the mapping being undone
  */
 void undo_map_in_kernel(void) {
+    alloc_region_t *region = alloc_state.region;
+
     const void *addr = alloc_state.latest_addr;
 
-    void *start = ALIGN_START_PTR(addr, PAGE_SIZE);
+    void *start = ALIGN_START_PTR(addr, region->page_size);
 
     shrink_mapping(start);
     

--- a/kernel/infrastructure/i686/cpuinfo.c
+++ b/kernel/infrastructure/i686/cpuinfo.c
@@ -77,12 +77,16 @@ static void enumerate_bootinfo_features(cpuinfo_t *cpuinfo, const bootinfo_t *bo
         cpuinfo->features |= CPU_FEATURE_CPUID;
     }
 
+    if(bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_NX)) {
+        cpuinfo->features |= CPU_FEATURE_NX;
+    }
+
     if(bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PAE)) {
         cpuinfo->features |= CPU_FEATURE_PAE;
     }
 
-    if(bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_NX)) {
-        cpuinfo->features |= CPU_FEATURE_NX;
+    if(bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PSE)) {
+        cpuinfo->features |= CPU_FEATURE_PSE;
     }
 }
 
@@ -500,7 +504,7 @@ static void identify_maxphyaddr(cpuinfo_t *cpuinfo, const cpuid_leafs_set *leafs
  */
 static void dump_features(const cpuinfo_t *cpuinfo) {
     info(
-        "  Features:%s%s%s%s%s%s%s%s%s%s",
+        "  Features:%s%s%s%s%s%s%s%s%s%s%s",
         (cpuinfo->features == 0) ? " (none)" : "",
         (cpuinfo->features & CPU_FEATURE_APIC) ? " apic" : "",
         (cpuinfo->features & CPU_FEATURE_CPUID) ? " cpuid" : "",
@@ -508,6 +512,7 @@ static void dump_features(const cpuinfo_t *cpuinfo) {
         (cpuinfo->features & CPU_FEATURE_PAE) ? " pae" : "",
         (cpuinfo->features & CPU_FEATURE_PAT) ? " pat" : "",
         (cpuinfo->features & CPU_FEATURE_PGE) ? " pge" : "",
+        (cpuinfo->features & CPU_FEATURE_PSE) ? " pse" : "",
         (cpuinfo->features & CPU_FEATURE_SSE) ? " sse" : "",
         (cpuinfo->features & CPU_FEATURE_SYSCALL) ? " syscall" : "",
         (cpuinfo->features & CPU_FEATURE_SYSENTER) ? " sysenter" : ""

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -345,7 +345,7 @@ void init_video_framebuffer(
         bootinfo->video_fb_addr,
         bootinfo->video_fb_size,
         JINUE_PROT_READ | JINUE_PROT_WRITE,
-        JINUE_MAP_WRITE_COMBINE
+        JINUE_MAP_WRITE_COMBINE | JINUE_MAP_LARGE_PAGES
     ); 
 
     initialize_console(

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -124,7 +124,6 @@ static void initialize_config(const bootinfo_t *bootinfo) {
     fb.height       = bootinfo->video_height;
     fb.pitch        = bootinfo->video_pitch;
     fb.pixel_format = bootinfo->video_pixel_format;
-    fb.size         = bootinfo->video_fb_size;
     fb.origin       = 0;
 
     const unsigned int viewport_width = console.width * FONT_WIDTH;
@@ -304,7 +303,9 @@ void init_video_framebuffer(
         return;
     }
 
-    if(bootinfo->video_fb_size < bootinfo->video_height * bootinfo->video_pitch) {
+    size_t mapping_size = bootinfo->video_height * bootinfo->video_pitch;
+
+    if(bootinfo->video_fb_size < mapping_size) {
         warn(WARNING "disabling video framebuffer because information passed by bootloader is inconsistent (size).");
         return;
     }
@@ -323,7 +324,7 @@ void init_video_framebuffer(
         return;
     }
 
-    if(bootinfo->video_fb_size > 10 * MB) {
+    if(mapping_size > 10 * MB) {
         /* Temporary limitation caused by memory management and performance
          * issues. Will be improved. */
         warn(WARNING "disabling video framebuffer because it is larger than the supported 10MB.");
@@ -338,15 +339,17 @@ void init_video_framebuffer(
 
     fb.backbuffer = boot_page_alloc_n(
         boot_alloc,
-        (bootinfo->video_fb_size + PAGE_SIZE - 1) / PAGE_SIZE
+        (mapping_size + PAGE_SIZE - 1) / PAGE_SIZE
     );
 
     fb.framebuffer = map_in_kernel(
         bootinfo->video_fb_addr,
-        bootinfo->video_fb_size,
+        mapping_size,
         JINUE_PROT_READ | JINUE_PROT_WRITE,
         JINUE_MAP_WRITE_COMBINE | JINUE_MAP_LARGE_PAGES
-    ); 
+    );
+
+    fb.size = mapping_size;
 
     initialize_console(
         &console,

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -655,7 +655,7 @@ static uint64_t map_arch_page_flags(int prot, int flags) {
  * machine_large_page_size() function to determine the size (and alignment
  * requirements) of pages in this region, whether large pages are supported or
  * not. This function ignores the JINUE_MAP_LARGE_PAGES flag and takes its
- * its decision to use large pages based solely on the address (addr argument).
+ * decision to use large pages based solely on the address (addr argument).
  *
  * @param vaddr virtual address of mapping
  * @param paddr address of page frame
@@ -788,6 +788,8 @@ bool machine_map_userspace(
 void machine_unmap_kernel(addr_t addr, size_t size) {
     /** ASSERTION: addr is aligned on a page boundary */
     assert( page_offset_of(addr) == 0 );
+
+    /* TODO implement support for large pages */
 
     pte_t *pte = lookup_kernel_page_table_entry(addr);
 

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -73,7 +73,16 @@
  * During kernel initialization, kernel page tables are pre-allocated
  * sequentially so, in essence, this pointer points to one big page table that
  * covers the whole part of the address space that belongs to the kernel. */
-pte_t *kernel_page_tables;
+static pte_t *kernel_page_tables;
+
+/** Start of kernel page directory entries
+ * 
+ * This page directory is the one allocated by the setup code and the one for
+ * the initial address space. It might get copied when creating other address
+ * spaces. For this reason, and because we expect kernel mappings to be global,
+ * any modifications to it (including e.g. large page mappings) must be done
+ * before new address spaces are created (i.e. before the first process). */
+static pte_t *kernel_page_directory;
 
 /** Number of entries per page tables
  *
@@ -81,8 +90,15 @@ pte_t *kernel_page_tables;
  *  512 (4kB / 8 bytes per entry) if PAE is enabled. */
 size_t entries_per_page_table;
 
+/** Large page size
+ * 
+ * 2MB if PAE is enabled
+ * 4MB if PAE is disabled but PSE is supported
+ * 4kB (fallback to normal page size) otherwise */
+static size_t large_page_size;
+
 /** true if PAE is enabled, false otherwise */
-bool pgtable_format_pae;
+static bool pgtable_format_pae;
 
 /** mask of valid page frame number bits */
 uint64_t page_frame_number_mask;
@@ -322,13 +338,16 @@ static void initialize_pat(void) {
  */
 void pmap_init(const bootinfo_t *bootinfo) {
     kernel_page_tables              = bootinfo->page_tables;
+    kernel_page_directory           = bootinfo->page_directory;
     initial_addr_space.cr3          = bootinfo->cr3;
     pgtable_format_pae              = cpu_has_feature(CPU_FEATURE_PAE);
 
     if(pgtable_format_pae) {
         initial_addr_space.top_level.pdpt = (pdpt_t *)PHYS_TO_VIRT_AT_16MB(bootinfo->cr3);
+        large_page_size = 2 * MB;
     } else {
         initial_addr_space.top_level.pd = bootinfo->page_directory;
+        large_page_size = cpu_has_feature(CPU_FEATURE_PSE) ? 4 * MB : 4 * KB;
     }
 
     entries_per_page_table  = pgtable_format_pae ? PAE_PAGE_TABLE_PTES :  NOPAE_PAGE_TABLE_PTES;
@@ -460,9 +479,6 @@ void pmap_switch_addr_space(addr_space_t *addr_space) {
  * @return pointer to page table entry
  */
 static pte_t *lookup_kernel_page_table_entry(const void *addr) {
-    /** ASSERTION: addr is aligned on a page boundary */
-    assert( page_offset_of(addr) == 0 );
-
     /** ASSERTION: addr is a kernel pointer */
     assert( is_kernel_pointer(addr) );
 
@@ -476,7 +492,24 @@ static pte_t *lookup_kernel_page_table_entry(const void *addr) {
      *    specify an address space. */
     return get_pte_with_offset(
         kernel_page_tables,
-        page_number_of((uintptr_t)addr - JINUE_KLIMIT));
+        page_number_of((uintptr_t)addr - JINUE_KLIMIT)
+    );
+}
+
+/**
+ * Lookup page directory entry for specified kernel address
+ *
+ * @param addr kernel address to look up
+ * @return pointer to page directory entry
+ */
+static pte_t *lookup_kernel_page_directory_entry(const void *addr) {
+    /** ASSERTION: addr is a kernel pointer */
+    assert( is_kernel_pointer(addr) );
+
+    return get_pte_with_offset(
+        kernel_page_directory,
+        page_number_of((uintptr_t)addr - JINUE_KLIMIT) / entries_per_page_table
+    );
 }
 
 /**
@@ -616,6 +649,13 @@ static uint64_t map_arch_page_flags(int prot, int flags) {
  * Kernel page tables are pre-allocated during kernel initialization so this is
  * guaranteed to succeed. There is also no need to specify an address space
  * since kernel mappings are global.
+ * 
+ * If the address is above LARGE_PAGES_AREA_ADDR (i.e. in the large pages
+ * mapping region), the mapping will use large pages if supported. Use the
+ * machine_large_page_size() function to determine the size (and alignment
+ * requirements) of pages in this region, whether large pages are supported or
+ * not. This function ignores the JINUE_MAP_LARGE_PAGES flag and takes its
+ * its decision to use large pages based solely on the address (addr argument).
  *
  * @param vaddr virtual address of mapping
  * @param paddr address of page frame
@@ -623,21 +663,44 @@ static uint64_t map_arch_page_flags(int prot, int flags) {
  * @param flags mapping flags
  */
 void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot, int flags) {
-    /** ASSERTION: we assume vaddr is aligned on a page boundary */
-    assert( page_offset_of(addr) == 0 );
+    uint64_t pte_flags = map_arch_page_flags(prot, flags) | X86_PTE_GLOBAL;
 
-    pte_t *pte = lookup_kernel_page_table_entry(addr);
+    bool has_large_pages = cpu_has_feature(CPU_FEATURE_PAE) || cpu_has_feature(CPU_FEATURE_PSE);
 
-    assert(pte != NULL);
+    if(has_large_pages && (uintptr_t)addr >= LARGE_PAGES_AREA_ADDR) {
+        /** ASSERTION: we assume vaddr is aligned on a large page boundary */
+        assert(((uintptr_t)addr & (large_page_size - 1)) == 0);
+        
+        pte_flags |= X86_PDE_PAGE_SIZE;
 
-    for(size_t offset = 0; offset < size; offset += PAGE_SIZE) {
-        set_pte(
-            get_pte_with_offset(pte, PAGE_NUMBER(offset)),
-            paddr + offset,
-            map_arch_page_flags(prot, flags) | X86_PTE_GLOBAL
-        );
+        pte_t *pte = lookup_kernel_page_directory_entry(addr);
+        
+        for(size_t offset = 0; offset < size; offset += large_page_size) {
+            set_pte(
+                /* TODO let's not do this division each iteration */
+                get_pte_with_offset(pte, PAGE_NUMBER(offset) / entries_per_page_table),
+                paddr + offset,
+                pte_flags
+            );
 
-        invlpg(addr + offset);
+            invlpg(addr + offset);
+        }
+    }
+    else {
+        /** ASSERTION: we assume vaddr is aligned on a page boundary */
+        assert( page_offset_of(addr) == 0 );
+
+        pte_t *pte = lookup_kernel_page_table_entry(addr);
+        
+        for(size_t offset = 0; offset < size; offset += PAGE_SIZE) {
+            set_pte(
+                get_pte_with_offset(pte, PAGE_NUMBER(offset)),
+                paddr + offset,
+                pte_flags
+            );
+
+            invlpg(addr + offset);
+        }
     }
 }
 
@@ -745,9 +808,20 @@ void machine_unmap_kernel(addr_t addr, size_t size) {
  * @return physical address of page frame
  */
 paddr_t machine_lookup_kernel_paddr(const void *addr) {
+    /** ASSERTION: addr is aligned on a page boundary */
+    assert( page_offset_of(addr) == 0 );
+
     pte_t *pte = lookup_kernel_page_table_entry(addr);
 
     assert(pte != NULL && pte_is_present(pte));
 
     return get_pte_paddr(pte);
+}
+
+/** Get large page size in bytes
+ * 
+ * @return large page size in bytes
+ */
+size_t machine_large_page_size(void) {
+    return large_page_size;
 }

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -675,10 +675,9 @@ void machine_map_kernel(addr_t addr, size_t size, paddr_t paddr, int prot, int f
 
         pte_t *pte = lookup_kernel_page_directory_entry(addr);
         
-        for(size_t offset = 0; offset < size; offset += large_page_size) {
+        for(size_t offset = 0, index = 0; offset < size; offset += large_page_size, ++index) {
             set_pte(
-                /* TODO let's not do this division each iteration */
-                get_pte_with_offset(pte, PAGE_NUMBER(offset) / entries_per_page_table),
+                get_pte_with_offset(pte, index),
                 paddr + offset,
                 pte_flags
             );

--- a/kernel/infrastructure/i686/pmap/pmap.c
+++ b/kernel/infrastructure/i686/pmap/pmap.c
@@ -786,19 +786,31 @@ bool machine_map_userspace(
  * @param addr address of page to unmap
  */
 void machine_unmap_kernel(addr_t addr, size_t size) {
-    /** ASSERTION: addr is aligned on a page boundary */
-    assert( page_offset_of(addr) == 0 );
+    bool has_large_pages = cpu_has_feature(CPU_FEATURE_PAE) || cpu_has_feature(CPU_FEATURE_PSE);
 
-    /* TODO implement support for large pages */
+    if(has_large_pages && (uintptr_t)addr >= LARGE_PAGES_AREA_ADDR) {
+        /** ASSERTION: we assume vaddr is aligned on a large page boundary */
+        assert(((uintptr_t)addr & (large_page_size - 1)) == 0);
 
-    pte_t *pte = lookup_kernel_page_table_entry(addr);
+        pte_t *pte = lookup_kernel_page_directory_entry(addr);
+        
+        for(size_t offset = 0, index = 0; offset < size; offset += large_page_size, ++index) {
+            clear_pte( get_pte_with_offset(pte, index) );
 
-    assert(pte != NULL);
+            invlpg(addr + offset);
+        }
+    }
+    else {
+        /** ASSERTION: addr is aligned on a page boundary */
+        assert( page_offset_of(addr) == 0 );
 
-    for(size_t offset = 0; offset < size; offset += PAGE_SIZE) {
-        clear_pte( get_pte_with_offset(pte, PAGE_NUMBER(offset)) );
+        pte_t *pte = lookup_kernel_page_table_entry(addr);
 
-        invlpg(addr + offset);
+        for(size_t offset = 0; offset < size; offset += PAGE_SIZE) {
+            clear_pte( get_pte_with_offset(pte, PAGE_NUMBER(offset)) );
+
+            invlpg(addr + offset);
+        }
     }
 }
 

--- a/kernel/interface/i686/setup/cpuid.c
+++ b/kernel/interface/i686/setup/cpuid.c
@@ -131,6 +131,8 @@ void detect_cpu_features(bootinfo_t *bootinfo) {
     basic1.eax = 1;
     cpuid(&basic1);
 
+    bootinfo->features |= (basic1.edx & CPUID_FEATURE_PSE) ? BOOTINFO_FEATURE_PSE : 0;
+
     bool has_pae = !!(basic1.edx & CPUID_FEATURE_PAE);
 
     if(!has_pae) {

--- a/kernel/interface/i686/setup/main32.c
+++ b/kernel/interface/i686/setup/main32.c
@@ -113,10 +113,7 @@ bootinfo_t *main32(const linux_boot_params_t linux_boot_params) {
 
     prepare_for_paging(bootinfo);
 
-    bool use_pae    = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PAE);
-    bool use_nx     = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_NX);
-
-    enable_paging(use_pae, use_nx, bootinfo->cr3);
+    enable_paging(bootinfo->cr3, bootinfo->features);
 
     adjust_bootinfo_pointers(&bootinfo);
 
@@ -126,7 +123,7 @@ bootinfo_t *main32(const linux_boot_params_t linux_boot_params) {
 
     /* Reload CR3 to invalidate TLBs so the changes by cleanup_after_paging()
      * take effect. */
-    enable_paging(use_pae, use_nx, bootinfo->cr3);
+    enable_paging(bootinfo->cr3, bootinfo->features);
 
     return bootinfo;
 }

--- a/kernel/interface/i686/setup/pmap.c
+++ b/kernel/interface/i686/setup/pmap.c
@@ -56,13 +56,28 @@ struct pte_t {
  */
 void allocate_page_tables(bootinfo_t *bootinfo) {
     bool use_pae = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PAE);
-    
+    bool use_pse = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PSE);
+
+    /* If large pages are supported, we reserve the region above
+     * LARGE_PAGES_AREA_ADDR for 2MB (PAE) or 4MB (32-bit legacy) large page
+     * mappings set directly in page directory entries. In that case, we
+     * don't allocate page tables for that region. If large pages are not
+     * supported, this region becomes a normal mapping region (i.e. we fall
+     * back to normal 4kB pages) so we allocate page tables for the whole
+     * kernel address space.
+     * 
+     * The PSE feature flag indicates support 4MB for large pages in legacy
+     * 32-bit paging mode. If PAE is supported, then 2MB large pages are
+     * supported (in PAE paging mode, which we always enable if supported). */
+    size_t num_4kb_pages = NUM_PAGES(
+        (use_pse || use_pae ? LARGE_PAGES_AREA_ADDR : ADDR_4GB) - JINUE_KLIMIT
+    );
     size_t per_table_bits = use_pae ? 9 : 10;
 
     /* kernel page tables */
     bootinfo->page_tables = alloc_pages(
         bootinfo,
-        NUM_PAGES(LARGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits) * PAGE_SIZE
+        num_4kb_pages / (1 << per_table_bits) * PAGE_SIZE
     );
     
     /* page directory */
@@ -149,13 +164,18 @@ static inline uint64_t *get_pdpt(const bootinfo_t *bootinfo) {
  */
 void initialize_page_tables(bootinfo_t *bootinfo, const data_segment_t *data_segment) {
     bool use_pae    = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PAE);
+    bool use_pse    = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PSE);
     uint64_t nx     = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_NX) ? X86_PTE_NX : 0;
+
+    size_t num_4kb_pages = NUM_PAGES(
+        (use_pse || use_pae ? LARGE_PAGES_AREA_ADDR : ADDR_4GB) - JINUE_KLIMIT
+    );
 
     clear_ptes(
         use_pae,
         bootinfo->page_tables,
         0,
-        NUM_PAGES(LARGE_PAGES_AREA_ADDR - JINUE_KLIMIT)
+        num_4kb_pages
     );
 
     /* map the kernel image */
@@ -224,7 +244,7 @@ void initialize_page_tables(bootinfo_t *bootinfo, const data_segment_t *data_seg
         use_pae,
         bootinfo->page_directory,
         (use_pae ? 0 : JINUE_KLIMIT) >> (PAGE_BITS + per_table_bits),
-        NUM_PAGES(LARGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits),
+        num_4kb_pages / (1 << per_table_bits),
         (uint32_t)bootinfo->page_tables | X86_PTE_READ_WRITE
     );
 

--- a/kernel/interface/i686/setup/pmap.c
+++ b/kernel/interface/i686/setup/pmap.c
@@ -59,14 +59,14 @@ void allocate_page_tables(bootinfo_t *bootinfo) {
     bool use_pse = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PSE);
 
     /* If large pages are supported, we reserve the region above
-     * LARGE_PAGES_AREA_ADDR for 2MB (PAE) or 4MB (32-bit legacy) large page
+     * LARGE_PAGES_AREA_ADDR for 2MB (PAE) or 4MB (32-bit legacy) large pages
      * mappings set directly in page directory entries. In that case, we
      * don't allocate page tables for that region. If large pages are not
      * supported, this region becomes a normal mapping region (i.e. we fall
      * back to normal 4kB pages) so we allocate page tables for the whole
      * kernel address space.
      * 
-     * The PSE feature flag indicates support 4MB for large pages in legacy
+     * The PSE feature flag indicates support for 4MB large pages in legacy
      * 32-bit paging mode. If PAE is supported, then 2MB large pages are
      * supported (in PAE paging mode, which we always enable if supported). */
     size_t num_4kb_pages = NUM_PAGES(

--- a/kernel/interface/i686/setup/pmap.c
+++ b/kernel/interface/i686/setup/pmap.c
@@ -62,7 +62,7 @@ void allocate_page_tables(bootinfo_t *bootinfo) {
     /* kernel page tables */
     bootinfo->page_tables = alloc_pages(
         bootinfo,
-        NUM_PAGES(ADDR_4GB - JINUE_KLIMIT) / (1 << per_table_bits) * PAGE_SIZE
+        NUM_PAGES(HUGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits) * PAGE_SIZE
     );
     
     /* page directory */
@@ -151,14 +151,14 @@ void initialize_page_tables(bootinfo_t *bootinfo, const data_segment_t *data_seg
     bool use_pae    = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_PAE);
     uint64_t nx     = bootinfo_has_feature(bootinfo, BOOTINFO_FEATURE_NX) ? X86_PTE_NX : 0;
 
-    /* map the kernel image */
     clear_ptes(
         use_pae,
         bootinfo->page_tables,
         0,
-        NUM_PAGES(ADDR_4GB - JINUE_KLIMIT)
+        NUM_PAGES(HUGE_PAGES_AREA_ADDR - JINUE_KLIMIT)
     );
 
+    /* map the kernel image */
     map_linear(
         use_pae,
         bootinfo->page_tables,
@@ -224,7 +224,7 @@ void initialize_page_tables(bootinfo_t *bootinfo, const data_segment_t *data_seg
         use_pae,
         bootinfo->page_directory,
         (use_pae ? 0 : JINUE_KLIMIT) >> (PAGE_BITS + per_table_bits),
-        NUM_PAGES(ADDR_4GB - JINUE_KLIMIT) / (1 << per_table_bits),
+        NUM_PAGES(HUGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits),
         (uint32_t)bootinfo->page_tables | X86_PTE_READ_WRITE
     );
 

--- a/kernel/interface/i686/setup/pmap.c
+++ b/kernel/interface/i686/setup/pmap.c
@@ -62,7 +62,7 @@ void allocate_page_tables(bootinfo_t *bootinfo) {
     /* kernel page tables */
     bootinfo->page_tables = alloc_pages(
         bootinfo,
-        NUM_PAGES(HUGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits) * PAGE_SIZE
+        NUM_PAGES(LARGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits) * PAGE_SIZE
     );
     
     /* page directory */
@@ -155,7 +155,7 @@ void initialize_page_tables(bootinfo_t *bootinfo, const data_segment_t *data_seg
         use_pae,
         bootinfo->page_tables,
         0,
-        NUM_PAGES(HUGE_PAGES_AREA_ADDR - JINUE_KLIMIT)
+        NUM_PAGES(LARGE_PAGES_AREA_ADDR - JINUE_KLIMIT)
     );
 
     /* map the kernel image */
@@ -224,7 +224,7 @@ void initialize_page_tables(bootinfo_t *bootinfo, const data_segment_t *data_seg
         use_pae,
         bootinfo->page_directory,
         (use_pae ? 0 : JINUE_KLIMIT) >> (PAGE_BITS + per_table_bits),
-        NUM_PAGES(HUGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits),
+        NUM_PAGES(LARGE_PAGES_AREA_ADDR - JINUE_KLIMIT) / (1 << per_table_bits),
         (uint32_t)bootinfo->page_tables | X86_PTE_READ_WRITE
     );
 

--- a/kernel/interface/i686/setup/setup32.asm
+++ b/kernel/interface/i686/setup/setup32.asm
@@ -204,21 +204,23 @@ start:
 
     ; -------------------------------------------------------------------------
     ; Function: enable_paging
-    ; C prototype: void enable_paging(bool use_pae, bool use_nx, uint32_t cr3)
+    ; C prototype: void enable_paging(uint32_t cr3, int bootinfo_features)
     ; -------------------------------------------------------------------------
     ; Enable paging and protect read-only pages from being written to by the
     ; kernel.
     ; -------------------------------------------------------------------------
     global enable_paging:function (enable_paging.end - enable_paging)
 enable_paging:
+    mov edx, dword [esp + 8]    ; second argument: bootinfo_features, allocated
+                                ; for the whole function
+    
     ; set page directory or PDPT address in CR3
-    mov eax, dword [esp + 12]   ; third argument: cr3
+    mov eax, dword [esp + 4]    ; first argument: cr3
     mov cr3, eax                ; set cr3
 
     ; check if PAE needs to be enabled
-    mov eax, dword [esp + 4]    ; first argument: use_pae
-    or al, al
-    jz .skip                    ; skip if use_pae is not set
+    test edx, BOOTINFO_FEATURE_PAE
+    jz .skip                    ; skip if feature "PAE" is not set
 
     ; enable PAE
     mov eax, cr4
@@ -226,9 +228,8 @@ enable_paging:
     mov cr4, eax
 
     ; check if No eXec (NX) protection needs to be enabled
-    mov eax, dword [esp + 8]    ; second argument: use_nx
-    or al, al
-    jz .skip                    ; skip if use_nx is not set
+    test edx, BOOTINFO_FEATURE_NX
+    jz .skip                    ; skip if feature "NX" is not set
 
     ; enable support for NX/XD bit
     mov ecx, MSR_EFER
@@ -237,6 +238,17 @@ enable_paging:
     wrmsr
 
 .skip:
+    ; check if Page Size Extension (PSE) can be enabled
+    ; meaningful when PAE is enabled, implied and ignored when PAE is enabled
+    test edx, BOOTINFO_FEATURE_PSE
+    jz .skip_pse                ; skip if feature "PSE" is not set
+
+    ; enable PSE
+    mov eax, cr4
+    or eax, X86_CR4_PSE
+    mov cr4, eax
+
+.skip_pse:
     ; enable paging (PG), prevent kernel from writing to read-only pages (WP)
     mov eax, cr0
     or eax, X86_CR0_PG | X86_CR0_WP

--- a/userspace/loader/utils.h
+++ b/userspace/loader/utils.h
@@ -32,6 +32,7 @@
 #ifndef LOADER_UTILS_H_
 #define LOADER_UTILS_H_
 
+#include <jinue/jinue.h>
 #include <stdbool.h>
 
 bool bool_getenv(const char *name);

--- a/userspace/testapp/Makefile
+++ b/userspace/testapp/Makefile
@@ -30,7 +30,13 @@
 jinue_root = ../..
 include $(jinue_root)/header.mk
 
-sources.c       	 = tests/abcd.c tests/ipc.c debug.c testapp.c utils.c
+sources.c = \
+	tests/abcd.c \
+	tests/ipc.c \
+	tests/scroll.c \
+	debug.c \
+	testapp.c \
+	utils.c
 testapp         	 = testapp
 stripped             = $(testapp)-stripped
 temp_ramdisk_fs		 = ramdisk-tmp

--- a/userspace/testapp/tests/scroll.c
+++ b/userspace/testapp/tests/scroll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2026 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
@@ -29,53 +29,41 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <jinue/jinue.h>
-#include <jinue/loader.h>
 #include <jinue/utils.h>
-#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
-#include "tests/abcd.h"
-#include "tests/ipc.h"
-#include "tests/scroll.h"
-#include "debug.h"
-#include "utils.h"
+#include "../utils.h"
+#include "scroll.h"
 
-int main(int argc, char *argv[]) {
-    /* Say hello. */
-    jinue_info("Jinue test app (%s) started.", argv[0]);
+static char sequence[16][20];
 
-    dump_cmdline_arguments(argc, argv);
-    dump_environ();
-    dump_auxvec();
-    dump_syscall_implementation();
-    dump_address_map();
-    dump_loader_memory_info();
-    dump_loader_ramdisk();
-
-    jinue_info("Blocking until loader exits...");
-
-    int status = jinue_exit_loader();
-
-    if(status < 0) {
-        return EXIT_FAILURE;
+void run_scroll_test(void) {
+    if(! bool_getenv("RUN_TEST_SCROLL")) {
+        return;
     }
 
-    jinue_info("Loader has exited.");
-
-    run_abcd_test();
-    run_ipc_test();
-    run_scroll_test();
-
-    if(bool_getenv("DEBUG_DO_REBOOT")) {
-        jinue_info("Rebooting.");
-        jinue_reboot();
+    for(int idx = 0; idx < 16; ++idx) {
+        memset(sequence[idx], ' ', 16);
+        sequence[idx][idx] = 'O';
+        sequence[idx][16] = '\0';
     }
 
-    while (1) {
-        jinue_yield_thread();
+    uint64_t lineno = 0;
+
+    while(true) {
+        int index = lineno % 32;
+
+        if(index >= 16) {
+            index = 32 - index - 1;
+        }
+
+        jinue_info(
+            "qwertyuiopasdfghjklzxcvbnm0123456789[%s]%020" PRIu64,
+            sequence[index],
+            lineno
+        );
+        ++lineno;
     }
-    
-    return EXIT_SUCCESS;
 }

--- a/userspace/testapp/tests/scroll.h
+++ b/userspace/testapp/tests/scroll.h
@@ -1,22 +1,22 @@
 /*
- * Copyright (C) 2019-2026 Philippe Aubertin.
+ * Copyright (C) 2026 Philippe Aubertin.
  * All rights reserved.
 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the author nor the names of other contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,53 +29,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <jinue/jinue.h>
-#include <jinue/loader.h>
-#include <jinue/utils.h>
-#include <errno.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include "tests/abcd.h"
-#include "tests/ipc.h"
-#include "tests/scroll.h"
-#include "debug.h"
-#include "utils.h"
+#ifndef TESTAPP_TEST_SCROLL_H_
+#define TESTAPP_TEST_SCROLL_H_
 
-int main(int argc, char *argv[]) {
-    /* Say hello. */
-    jinue_info("Jinue test app (%s) started.", argv[0]);
+void run_scroll_test(void);
 
-    dump_cmdline_arguments(argc, argv);
-    dump_environ();
-    dump_auxvec();
-    dump_syscall_implementation();
-    dump_address_map();
-    dump_loader_memory_info();
-    dump_loader_ramdisk();
-
-    jinue_info("Blocking until loader exits...");
-
-    int status = jinue_exit_loader();
-
-    if(status < 0) {
-        return EXIT_FAILURE;
-    }
-
-    jinue_info("Loader has exited.");
-
-    run_abcd_test();
-    run_ipc_test();
-    run_scroll_test();
-
-    if(bool_getenv("DEBUG_DO_REBOOT")) {
-        jinue_info("Rebooting.");
-        jinue_reboot();
-    }
-
-    while (1) {
-        jinue_yield_thread();
-    }
-    
-    return EXIT_SUCCESS;
-}
+#endif


### PR DESCRIPTION
* Support 4 MB/2 MB pages for kernel mappings. Support for user space mappings will be added in a future PR.
* Map the video framebuffer with large pages to reduce TLB pressure. The same will be done with the back buffer in a future PR since this requires changes to how it is allocated.