### PR TITLE
Remove pixel backbuffer

### DIFF
--- a/include/kernel/infrastructure/i686/drivers/console.h
+++ b/include/kernel/infrastructure/i686/drivers/console.h
@@ -37,29 +37,35 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef void (*console_write_func_t)(unsigned char c, uint8_t loglevel);
-
-typedef void (*console_scroll_func_t)(void);
-
 typedef struct {
-    unsigned int            width;
-    unsigned int            height;
-    unsigned int            row;
-    unsigned int            col;
-    console_write_func_t    write_func;
-    console_scroll_func_t   scroll_func;
+    unsigned char   *buffer;
+    unsigned int     width;
+    unsigned int     height;
+    unsigned int     row;
+    unsigned int     col;
+    uint8_t          erase_colour;
 } console_t;
 
 void initialize_console(
-    console_t               *console,
-    unsigned int             width,
-    unsigned int             height,
-    console_write_func_t     write_func,
-    console_scroll_func_t    scroll_func
+    console_t       *console,
+    unsigned char   *buffer,
+    unsigned int     width,
+    unsigned int     height,
+    uint8_t          erase_colour
+);
+
+void allocate_console(
+    console_t       *console,
+    boot_alloc_t    *boot_alloc,
+    unsigned int     width,
+    unsigned int     height,
+    uint8_t          erase_colour
 );
 
 size_t console_text_buffer_size(unsigned int width, unsigned int height);
 
-void console_write(console_t *console, const char *str, size_t length, uint8_t loglevel);
+void erase_console(console_t *console);
+
+void console_write(console_t *console, const char *str, size_t length, uint8_t colour);
 
 #endif

--- a/include/kernel/infrastructure/i686/drivers/vga.h
+++ b/include/kernel/infrastructure/i686/drivers/vga.h
@@ -33,7 +33,6 @@
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_DRIVERS_VGA_H
 
 #include <kernel/infrastructure/i686/drivers/asm/vga.h>
-#include <kernel/interface/i686/types.h>
 #include <kernel/types.h>
 
 void vga_init(const config_t *config);

--- a/include/kernel/infrastructure/i686/drivers/vga.h
+++ b/include/kernel/infrastructure/i686/drivers/vga.h
@@ -33,6 +33,7 @@
 #define JINUE_KERNEL_INFRASTRUCTURE_I686_DRIVERS_VGA_H
 
 #include <kernel/infrastructure/i686/drivers/asm/vga.h>
+#include <kernel/interface/i686/types.h>
 #include <kernel/types.h>
 
 void vga_init(const config_t *config);

--- a/include/kernel/infrastructure/i686/exports/asm/machine.h
+++ b/include/kernel/infrastructure/i686/exports/asm/machine.h
@@ -34,13 +34,12 @@
 
 #include <kernel/utils/asm/utils.h>
 
-/* This region is currently only used to map the video framebuffer and its
- * back buffer. We reserve 128MB each to support 8K resolutions, plus a bit
- * more to have some margin in case they aren't aligned on a large page
- * boundary. */
-#define LARGE_PAGES_AREA_SIZE   (272 * MB)
+/* This region is currently only used to map the video framebuffer. At 8K
+ * resolutions and 4 bytes per pixel, this requires about 128MB. We want to
+ * have some margin in case the framebuffer is not properly aligned. */
+#define LARGE_PAGES_AREA_SIZE   (192 * MB)
 
-#define LARGE_PAGES_AREA_ADDR   0xef000000
+#define LARGE_PAGES_AREA_ADDR   0xf4000000
 
 #define MAPPING_AREA_SIZE       (64 * MB)
 

--- a/include/kernel/interface/i686/types.h
+++ b/include/kernel/interface/i686/types.h
@@ -61,7 +61,6 @@ typedef struct {
     uint8_t                  cpu_vendor;
     uint32_t                 setup_signature;
     uint8_t                  video_type;
-    uint8_t                  video_depth;
     uint8_t                  video_pixel_format;
     uint16_t                 video_width;
     uint16_t                 video_height;

--- a/kernel/infrastructure/i686/drivers/console.c
+++ b/kernel/infrastructure/i686/drivers/console.c
@@ -44,6 +44,7 @@
 #include <kernel/machine/asm/machine.h>
 #include <kernel/utils/asm/ascii.h>
 #include <kernel/utils/utils.h>
+#include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -78,6 +79,7 @@ void initialize_console(
  * function must only be called during boot-time initialization.
  * 
  * @param console the console state structure
+ * @param boot_alloc boot-time memory allocator
  * @param width screen width in characters
  * @param height screen height in characters
  * @param erase_colour colour to erase with when erasing and scrolling
@@ -178,7 +180,7 @@ static void write_character(console_t *console, char c, uint8_t colour) {
         break;
     
     default:
-        if(c >= 0x20 && c < 0x7f) {
+        if(isprint(c)) {
             const unsigned int offset = console->width * console->row + console->col;
             console->buffer[2 * offset] = (unsigned char)c;
             console->buffer[2 * offset + 1] = colour;

--- a/kernel/infrastructure/i686/drivers/console.c
+++ b/kernel/infrastructure/i686/drivers/console.c
@@ -29,37 +29,87 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* This file contains code shared by the VGA (text) and video framebuffer
+ * drivers. For the VGA driver, the underlying buffer we are manipulating in
+ * this file is the actual VGA hardware buffer at 0xb8000 while, for the
+ * framebuffer driver, it is a temporary text buffer that is then used as the
+ * for rendering the characters in the video framebuffer.
+ * 
+ * The format is imposed by VGA, i.e. two bytes per character where the first
+ * byte is the character code and the second byte is the colour. */
+
 #include <kernel/domain/services/logging.h>
 #include <kernel/infrastructure/i686/drivers/console.h>
 #include <kernel/infrastructure/i686/boot_alloc.h>
 #include <kernel/machine/asm/machine.h>
 #include <kernel/utils/asm/ascii.h>
 #include <kernel/utils/utils.h>
-#include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>
 
 /** Initialize the console configuration and state
  * 
  * @param console the console state structure
+ * @param buffer pointer to the buffer, mapped
  * @param width screen width in characters
  * @param height screen height in characters
- * @param write_func string write callback function
- * @param scroll_func text scrolling callback function
+ * @param erase_colour colour to erase with when erasing and scrolling
  */
 void initialize_console(
-    console_t               *console,
-    unsigned int             width,
-    unsigned int             height,
-    console_write_func_t     write_func,
-    console_scroll_func_t    scroll_func
-){
+    console_t       *console,
+    unsigned char   *buffer,
+    unsigned int     width,
+    unsigned int     height,
+    uint8_t          erase_colour
+) {
     info("Initializing console with size %ux%u.", width, height);
 
     console->width = width;
     console->height = height;
-    console->write_func = write_func;
-    console->scroll_func = scroll_func;
+    console->buffer = buffer;
+    console->erase_colour = erase_colour;
+    console->row = 0;
+    console->col = 0;
+}
+
+/** Allocate text buffer and initialize the console configuration and state
+ * 
+ * The text buffer is allocated using the boot-time page allocator, so this
+ * function must only be called during boot-time initialization.
+ * 
+ * @param console the console state structure
+ * @param width screen width in characters
+ * @param height screen height in characters
+ * @param erase_colour colour to erase with when erasing and scrolling
+ */
+void allocate_console(
+    console_t       *console,
+    boot_alloc_t    *boot_alloc,
+    unsigned int     width,
+    unsigned int     height,
+    uint8_t          erase_colour
+) {
+    size_t size = ALIGN_END(2 * width * height, PAGE_SIZE);
+
+    unsigned char *buffer = boot_page_alloc_n(boot_alloc, size / PAGE_SIZE);
+
+    initialize_console(console, buffer, width, height, erase_colour);
+}
+
+/** Erase the console and set position to home
+ * 
+ * @param console the console state structure
+ */
+void erase_console(console_t *console) {
+    unsigned int idx = 0;
+
+    size_t size = 2 * console->width * console->height;
+    
+    while(idx < size) {
+        console->buffer[idx++] = ' ';
+        console->buffer[idx++] = console->erase_colour;
+    }
+
     console->row = 0;
     console->col = 0;
 }
@@ -86,18 +136,29 @@ static void scroll_text(console_t *console) {
         return;
     }
 
-    --console->row;
+    unsigned char *di = console->buffer;
+    unsigned char *si = &console->buffer[2 * console->width];
+    unsigned int idx;
+    
+    for(idx = 0; idx < 2 * console->width * (console->height - 1); ++idx) {
+        *(di++) = *(si++);
+    }
+    
+    for(idx = 0; idx < console->width; ++idx) {
+        *(di++) = ' ';
+        *(di++) = console->erase_colour;
+    }
 
-    console->scroll_func();    
+    --console->row;
 }
 
 /** Write a character to the console text buffer
  * 
  * @param console console state structure
  * @param c character to write
- * @param loglevel log level of written character
+ * @param colour colour number
  */
-static void write_character(console_t *console, char c, uint8_t loglevel) {
+static void write_character(console_t *console, char c, uint8_t colour) {
     switch(c) {
     /* linefeed - actually does cr + lf */
     case CHAR_LF:
@@ -111,16 +172,17 @@ static void write_character(console_t *console, char c, uint8_t loglevel) {
         const unsigned int skip = CONSOLE_TAB_WIDTH - (console->col % CONSOLE_TAB_WIDTH);
 
         for(int idx = 0; idx < skip; ++idx) {
-            /* The recusive call takes care of line wrapping if needed. There is at more one
-             * level of recursion because the character is fixed to a space. */
-            write_character(console, ' ', loglevel);
+            write_character(console, ' ', colour);
         }
     }
         break;
     
     default:
-        if(isprint(c)) {
-            console->write_func(c, loglevel);
+        if(c >= 0x20 && c < 0x7f) {
+            const unsigned int offset = console->width * console->row + console->col;
+            console->buffer[2 * offset] = (unsigned char)c;
+            console->buffer[2 * offset + 1] = colour;
+            
             console->col += 1;
             wrap_text(console);
         }
@@ -134,12 +196,12 @@ static void write_character(console_t *console, char c, uint8_t loglevel) {
  * @param console console state structure
  * @param str string to write
  * @param length length of the string
- * @param loglevel log level of written text
+ * @param colour colour number of written text
  */
-void console_write(console_t *console, const char *str, size_t length, uint8_t loglevel) {
+void console_write(console_t *console, const char *str, size_t length, uint8_t colour) {
     for(int idx = 0; idx < length; ++idx) {
-        write_character(console, str[idx], loglevel);
+        write_character(console, str[idx], colour);
     }
 
-    write_character(console, '\n', loglevel);
+    write_character(console, '\n', colour);
 }

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -47,12 +47,6 @@
 /** console abstraction */
 static console_t console;
 
-/** base address of mapped video text buffer */
-unsigned char *video_base_addr;
-
-/** colour with which the text buffer is erased */
-uint8_t erase_colour;
-
 /** log ring buffer reader */
 static log_reader_t log_reader;
 
@@ -99,21 +93,6 @@ static void update_cursor_position(void) {
     write_crtc_reg(VGA_CRTC_CURSOR_LOW, l);
 }
 
-/** Erase the text buffer
- * 
- * @param console the console state structure
- */
-void erase_text_buffer(void) {
-    size_t size = 2 * console.width * console.height;
-
-    unsigned int idx = 0;
-    
-    while(idx < size) {
-        video_base_addr[idx++] = ' ';
-        video_base_addr[idx++] = erase_colour;
-    }
-}
-
 /** Map a log level to the appropriate VGA colour number.
  * 
  * @param loglevel the log level
@@ -143,36 +122,6 @@ static void initialize_registers(void) {
     write_misc_out_reg(read_misc_out_reg() | 1);
 }
 
-/** Character write console callback function
- * 
- * @param c ASCII code of character to write
- * @param loglevel log level
- */
-static void do_write(unsigned char c, uint8_t loglevel) {
-    size_t offset = console.width * console.row + console.col;
-    video_base_addr[2 * offset] = c;
-    video_base_addr[2 * offset + 1] = map_colour(loglevel);
-}
-
-/** Console scrolling callback function
- * 
- * Scrolls up by one text line and erases the bottom line.
- */
-static void do_scroll(void) {
-    unsigned char *di = video_base_addr;
-    unsigned char *si = &video_base_addr[2 * console.width];
-    unsigned int idx;
-    
-    for(idx = 0; idx < 2 * console.width * (console.height - 1); ++idx) {
-        *(di++) = *(si++);
-    }
-    
-    for(idx = 0; idx < console.width; ++idx) {
-        *(di++) = ' ';
-        *(di++) = erase_colour;
-    }
-}
-
 /** Logging callback function.
  * 
  * This function is registered as the logging callback function and is called
@@ -181,7 +130,9 @@ static void do_scroll(void) {
  * @param event logging event
 */
 static void do_log(const log_event_t *event) {
-    console_write(&console, event->message, event->length, event->loglevel);
+    uint8_t colour = map_colour(event->loglevel);
+
+    console_write(&console, event->message, event->length, colour);
 
     update_cursor_position();
 }
@@ -208,21 +159,25 @@ void vga_init(const config_t *config) {
 
     initialize_registers();
 
-    video_base_addr = map_in_kernel(
+    unsigned char *video_base_addr = map_in_kernel(
         VGA_TEXT_VID_BASE,
         VGA_TEXT_VID_TOP - VGA_TEXT_VID_BASE,
         JINUE_PROT_READ | JINUE_PROT_WRITE,
         JINUE_MAP_UNCACHEABLE
     );
 
-    initialize_console(&console, VGA_WIDTH, VGA_LINES, do_write, do_scroll);
+    initialize_console(
+        &console,
+        video_base_addr,
+        VGA_WIDTH,
+        VGA_LINES,
+        /* This mostly affects the colour of the cursor, which is typically
+         * located in an erased area. Setting this to black will make the
+         * cursor disappear even if otherwise enabled in registers. */
+        map_colour(JINUE_LOG_LEVEL_INFO)
+    );
 
-    /* This mostly affects the colour of the cursor, which is typically
-     * located in an erased area. Setting this to black will make the
-     * cursor disappear even if otherwise enabled in registers. */
-    erase_colour = map_colour(JINUE_LOG_LEVEL_INFO);
-
-    erase_text_buffer();
+    erase_console(&console);
 
     update_cursor_position();
 

--- a/kernel/infrastructure/i686/drivers/vga.c
+++ b/kernel/infrastructure/i686/drivers/vga.c
@@ -130,9 +130,7 @@ static void initialize_registers(void) {
  * @param event logging event
 */
 static void do_log(const log_event_t *event) {
-    uint8_t colour = map_colour(event->loglevel);
-
-    console_write(&console, event->message, event->length, colour);
+    console_write(&console, event->message, event->length, map_colour(event->loglevel));
 
     update_cursor_position();
 }

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -39,10 +39,8 @@
 #include <kernel/infrastructure/i686/drivers/videofbfont.h>
 #include <kernel/infrastructure/i686/pmap/pmap.h>
 #include <kernel/infrastructure/i686/barriers.h>
-#include <kernel/infrastructure/i686/boot_alloc.h>
 #include <kernel/infrastructure/i686/platform.h>
 #include <kernel/interface/i686/bootinfo.h>
-#include <kernel/machine/asm/machine.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
@@ -75,44 +73,20 @@ const uint8_t reference_colours[][3] = {
 #define NUM_COLOURS (sizeof(reference_colours) / sizeof(reference_colours[0]))
 
 /** colours transformed for the current pixel format */
-uint8_t colours[NUM_COLOURS][3];
+uint8_t colours[NUM_COLOURS][4];
 
-/** framebuffer/backbuffer configuration and state */
+/** framebuffer configuration */
 static struct {
-    /* buffers */
-    
-    /** frame buffer */
-    uint8_t     *framebuffer;
-    /** back buffer */
-    uint8_t     *backbuffer;
-
-    /* configuration */
-
-    /** buffer total size */
-    size_t       size;
-    /* total width in pixels */
-    uint16_t     width;
+    /** total width in pixels */
+    unsigned int     width;
     /** total height in pixels */
-    uint16_t     height;
+    unsigned int     height;
     /** total size of a line in bytes */
-    uint16_t     pitch;
-    /** start of viewport from the left in pixels */
-    uint16_t     left;
-    /** start of viewport from the top in pixels */
-    uint16_t     top;
+    unsigned int     pitch;
     /** pixel format - one of the VIDEO_PIXEL_FORMAT_xx constants */
-    uint8_t      pixel_format;
-    /** colour bytes per pixels */
-    uint8_t      bpp;
-    /** non-colour bytes per pixels */
-    uint8_t      skip;
-
-    /* state */
-
-    /** Text line index of first text line in the back buffer
-     * 
-     * Used for zero copy scrolling. */
-    uint16_t     origin;
+    unsigned int     pixel_format;
+    /** frame buffer base address */
+    uint8_t         *base_addr;
 } fb;
 
 /** Initialize the configuration structure
@@ -124,26 +98,13 @@ static void initialize_config(const bootinfo_t *bootinfo) {
     fb.height       = bootinfo->video_height;
     fb.pitch        = bootinfo->video_pitch;
     fb.pixel_format = bootinfo->video_pixel_format;
-    fb.origin       = 0;
-
-    const unsigned int viewport_width = console.width * FONT_WIDTH;
-    const unsigned int viewport_height = console.height * FONT_HEIGHT;
-
-    /* Center viewport/text area */
-    fb.left             = (fb.width - viewport_width) / 2;
-    fb.top              = (fb.height - viewport_height) / 2;
-
-    /* Varies according to pixel format but currently the same for all four
-     * supported pixel formats. */
-    fb.bpp = 3;
-    fb.skip = bootinfo->video_depth / 8 - fb.bpp;
 }
 
 /** Initialize the colours array according to pixel format
  * 
  * Must be called after initialize_config().
  */
-static void initalize_colours(void) {
+static void initialize_colours(void) {
     for(int idx = 0; idx < NUM_COLOURS; ++idx) {
         switch(fb.pixel_format) {
         case VIDEO_PIXEL_FORMAT_RGB888:
@@ -151,115 +112,106 @@ static void initalize_colours(void) {
             colours[idx][0] = reference_colours[idx][0];
             colours[idx][1] = reference_colours[idx][1];
             colours[idx][2] = reference_colours[idx][2];
+            /* Only relevant for RGBA 8888 but won't hurt otherwise since it
+             * just won't be read. */
+            colours[idx][3] = 0;
             break;
         case VIDEO_PIXEL_FORMAT_BGR888:
         case VIDEO_PIXEL_FORMAT_BGRA8888:
             colours[idx][0] = reference_colours[idx][2];
             colours[idx][1] = reference_colours[idx][1];
             colours[idx][2] = reference_colours[idx][0];
+            colours[idx][3] = 0;
             break;
         }
     }
 }
 
-/** Erase the back buffer
+/** map pixel format to bytes per pixel
  * 
- * To erase the frame buffer, erase the back buffer and then call
- * refresh_framebuffer().
+ * This function returns -1 if the pixel format is unsupported. This is checked
+ * during initialization and does not need to be handled elsewhere.
+ * 
+ * @param pixel_format pixel format (VIDEO_PIXEL_FORMAT_xx value)
+ * @return bytes per pixel, -1 for unsupported format
  */
-static void erase_backbuffer(void) {
-    unsigned char *line_addr = fb.backbuffer;
+static int map_bpp(unsigned int pixel_format) {
+    switch(fb.pixel_format) {
+    case VIDEO_PIXEL_FORMAT_RGB888:
+    case VIDEO_PIXEL_FORMAT_BGR888:
+        return 3;
+    case VIDEO_PIXEL_FORMAT_RGBA8888:
+    case VIDEO_PIXEL_FORMAT_BGRA8888:
+        return 4;
+    default:
+        return -1;
+    }
+}
+
+/** Erase the framebuffer */
+static void clear_framebuffer(void) {
+    unsigned char *line_addr = fb.base_addr;
+
+    const unsigned int bpp = map_bpp(fb.pixel_format);
 
     for(int y = 0; y < fb.height; ++y) {
-        memset(line_addr, 0, fb.width * (fb.bpp + fb.skip));
+        memset(line_addr, 0, fb.width * bpp);
         line_addr += fb.pitch;
     }
-
-    fb.origin = 0;
-}
-
-/** Compute absolute row index from row index relative to origin */
-static inline unsigned int from_origin(unsigned int row) {
-    unsigned int sum = row + fb.origin;
-    return sum < console.height ? sum : sum - console.height;
-}
-
-/** Compute byte offset of start of text row from row index */
-static inline unsigned int row(unsigned int row) {
-    return (row * FONT_HEIGHT + fb.top) * fb.pitch;
-}
-
-/** Compute byte offset from row start from column index */
-static inline unsigned int column(unsigned int col) {
-    return (col * FONT_WIDTH + fb.left) * (fb.bpp + fb.skip);
-}
-
-/** Copy pixels from the back buffer to the frane buffer */
-static void refresh_framebuffer(void) {   
-    /* When the origin is on line zero, we copy the whole back buffer content
-     * instead of only the viewport lines.
-     *
-     * Edge case to consider: when we refresh after erasing the back buffer, we
-     * want to copy all the lines so the whole frame buffer is also erased. */
-    if(fb.origin == 0) {
-        memcpy(fb.framebuffer, fb.backbuffer, fb.size);
-        return;
-    }
-
-    unsigned int top_rows = console.height - from_origin(0);
-
-    memcpy(
-        &fb.framebuffer[row(0)],
-        &fb.backbuffer[row(from_origin(0))],
-        top_rows * FONT_HEIGHT * fb.pitch
-    );
-
-    memcpy(
-        &fb.framebuffer[row(top_rows)],
-        &fb.backbuffer[row(0)],
-        (console.height - top_rows) * FONT_HEIGHT * fb.pitch
-    );
 
     store_barrier();
 }
 
-/** Character write console callback function
- * 
- * @param c ASCII code of character to write
- * @param loglevel log level
- */
-static void do_write(unsigned char c, uint8_t loglevel) {
-    const uint8_t *const colour = colours[
-        loglevel < JINUE_LOG_LEVEL_DEBUG ? loglevel : JINUE_LOG_LEVEL_DEBUG
-    ];
+// TODO make this function static again
+/** Refresh the framebuffer with the content of the console text buffer */
+void refresh_framebuffer(void) {
+    const unsigned int viewport_height = console.height * FONT_HEIGHT;
+    
+    /* Let's center the viewport vertically. Let's not center horizontally to
+     * preserve alignment. */
+    const unsigned int top = (fb.height - viewport_height) / 2;
+    const unsigned int bpp = map_bpp(fb.pixel_format);
 
-    uint8_t *start = &fb.backbuffer[row(from_origin(console.row)) + column(console.col)];
+    for(unsigned int y = 0; y < viewport_height; ++y) {
+        uint8_t *wrptr = &fb.base_addr[(y + top) * fb.pitch];
 
-    for(unsigned int y = 0; y < FONT_HEIGHT; ++y) {
-        const uint8_t font_byte = videofbfont[(c - 0x20) * FONT_HEIGHT + y];
-        
-        uint8_t *wrptr = start;
+        unsigned char *text_line = &console.buffer[2 * (y / FONT_HEIGHT) * console.width];
 
-        for(uint8_t mask = 0x80; mask != 0; mask >>= 1) {
-            for(unsigned int byte_index = 0; byte_index < fb. bpp; ++byte_index) {
-                *(wrptr++) = (font_byte & mask) ? colour[byte_index] : 0;
+        for(unsigned int col = 0; col < console.width; ++col) {
+            uint8_t c = text_line[2 * col] - 0x20;
+            uint8_t colour_index = text_line[2 * col + 1];
+            
+            const uint8_t *const colour = colours[colour_index];
+            const uint8_t font_byte = videofbfont[c * FONT_HEIGHT + y % FONT_HEIGHT];
+
+            for(uint8_t mask = 0x80; mask != 0; mask >>= 1) {
+                if(bpp == 4) {
+                    *(uint32_t *)wrptr =  (font_byte & mask) ? *(uint32_t *)colour : 0;
+                    wrptr += 4;
+                }
+                else {
+                    for(unsigned int byte_index = 0; byte_index < bpp; ++byte_index) {
+                        *(wrptr++) = (font_byte & mask) ? colour[byte_index] : 0;
+                    }
+                }
             }
-            wrptr += fb.skip;
         }
-
-        start += fb.pitch;
     }
+
+    store_barrier();
 }
 
-/** Console scrolling callback function
+/** Map a log level to the appropriate colour number.
  * 
- * Scrolls up by one text line and erases the bottom line.
+ * @param loglevel the log level
+ * @return colour number
  */
-static void do_scroll(void) {
-    fb.origin = from_origin(1);
+static uint8_t map_colour(int loglevel) {
+    if(loglevel > JINUE_LOG_LEVEL_DEBUG) {
+        return JINUE_LOG_LEVEL_DEBUG;
+    }
 
-    /* Erase the bottom line */
-    memset(&fb.backbuffer[row(from_origin(console.height - 1))], 0, FONT_HEIGHT * fb.pitch);
+    return loglevel;
 }
 
 /** Logging callback function.
@@ -270,8 +222,13 @@ static void do_scroll(void) {
  * @param event logging event
 */
 static void do_log(const log_event_t *event) {
-    console_write(&console, event->message, event->length, event->loglevel);
-    
+    console_write(
+        &console,
+        event->message,
+        event->length,
+        map_colour(event->loglevel)
+    );
+
     refresh_framebuffer();
 }
 
@@ -282,9 +239,9 @@ static void do_log(const log_event_t *event) {
  * @param boot_alloc boot-time memory allocator
  */
 void init_video_framebuffer(
-    const config_t *config,
-    const bootinfo_t *bootinfo,
-    boot_alloc_t *boot_alloc
+    const config_t      *config,
+    const bootinfo_t    *bootinfo,
+    boot_alloc_t        *boot_alloc
 ) {
     if(! config->machine.vga_enable) {
         return;
@@ -298,12 +255,19 @@ void init_video_framebuffer(
         return;
     }
 
-    if(bootinfo->video_pitch < bootinfo->video_width * (bootinfo->video_depth / 8)) {
+    const int bpp = map_bpp(bootinfo->video_pixel_format);
+
+    if(bpp < 0) {
+        warn(WARNING "disabling video framebuffer because pixel format is unsupported.");
+        return;
+    }
+
+    if(bootinfo->video_pitch < bootinfo->video_width * bpp) {
         warn(WARNING "disabling video framebuffer because information passed by bootloader is inconsistent (pitch).");
         return;
     }
 
-    size_t mapping_size = bootinfo->video_height * bootinfo->video_pitch;
+    const size_t mapping_size = bootinfo->video_height * bootinfo->video_pitch;
 
     if(bootinfo->video_fb_size < mapping_size) {
         warn(WARNING "disabling video framebuffer because information passed by bootloader is inconsistent (size).");
@@ -317,17 +281,8 @@ void init_video_framebuffer(
         return;
     }
 
-    if(bootinfo->video_width > 1024 || bootinfo->video_height > 768) {
-        /* Temporary limitation caused by memory management and performance
-         * issues. Will be improved. */
-        warn(WARNING "disabling video framebuffer because resolution is above 1024x768 supported maximum.");
-        return;
-    }
-
-    if(mapping_size > 10 * MB) {
-        /* Temporary limitation caused by memory management and performance
-         * issues. Will be improved. */
-        warn(WARNING "disabling video framebuffer because it is larger than the supported 10MB.");
+    if(mapping_size > 128 * MB) {
+        warn(WARNING "disabling video framebuffer because it is larger than the supported 128MB.");
         return;
     }
 
@@ -337,35 +292,28 @@ void init_video_framebuffer(
         bootinfo->video_height
     );
 
-    fb.backbuffer = boot_page_alloc_n(
-        boot_alloc,
-        (mapping_size + PAGE_SIZE - 1) / PAGE_SIZE
-    );
-
-    fb.framebuffer = map_in_kernel(
-        bootinfo->video_fb_addr,
-        mapping_size,
-        JINUE_PROT_READ | JINUE_PROT_WRITE,
-        JINUE_MAP_WRITE_COMBINE | JINUE_MAP_LARGE_PAGES
-    );
-
-    fb.size = mapping_size;
-
-    initialize_console(
-        &console,
-        bootinfo->video_width / FONT_WIDTH,
-        bootinfo->video_height / FONT_HEIGHT,
-        do_write,
-        do_scroll
-    );
-
     initialize_config(bootinfo);
 
-    initalize_colours();   
+    initialize_colours();
 
-    erase_backbuffer();
+    fb.base_addr = map_in_kernel(
+        bootinfo->video_fb_addr,
+        bootinfo->video_fb_size,
+        JINUE_PROT_READ | JINUE_PROT_WRITE,
+        JINUE_MAP_WRITE_COMBINE | JINUE_MAP_LARGE_PAGES
+    );    
 
-    refresh_framebuffer();
+    clear_framebuffer();
+
+    allocate_console(
+        &console,
+        boot_alloc,
+        bootinfo->video_width / FONT_WIDTH,
+        bootinfo->video_height / FONT_HEIGHT,
+        JINUE_LOG_LEVEL_INFO
+    );
+
+    erase_console(&console);
 
     initialize_log_reader(&log_reader, do_log);
 

--- a/kernel/infrastructure/i686/drivers/videofb.c
+++ b/kernel/infrastructure/i686/drivers/videofb.c
@@ -162,9 +162,8 @@ static void clear_framebuffer(void) {
     store_barrier();
 }
 
-// TODO make this function static again
 /** Refresh the framebuffer with the content of the console text buffer */
-void refresh_framebuffer(void) {
+static void refresh_framebuffer(void) {
     const unsigned int viewport_height = console.height * FONT_HEIGHT;
     
     /* Let's center the viewport vertically. Let's not center horizontally to

--- a/kernel/infrastructure/i686/video.c
+++ b/kernel/infrastructure/i686/video.c
@@ -86,7 +86,6 @@ void dump_video_information(const bootinfo_t *bootinfo) {
 
     if(video_type == VIDEO_TYPE_FRAMEBUFFER) {
         info("  resolution: %" PRIu16 "x%" PRIu16,  bootinfo->video_width, bootinfo->video_height);
-        info("  depth: %" PRIu8, bootinfo->video_depth);
         info("  pixel format: %s", pixel_format_string(bootinfo->video_pixel_format));
         info("  pitch: %" PRIu16, bootinfo->video_pitch);
         info("  framebuffer: addr 0x%" PRIx64 " size 0x%" PRIx32, bootinfo->video_fb_addr, bootinfo->video_fb_size);

--- a/kernel/interface/i686/setup/linux.c
+++ b/kernel/interface/i686/setup/linux.c
@@ -157,7 +157,6 @@ static void set_video_info(bootinfo_t *bootinfo, const linux_boot_params_t linux
     }
 
     bootinfo->video_type = VIDEO_TYPE_FRAMEBUFFER;
-    bootinfo->video_depth = screen_info->lfb_depth;
     bootinfo->video_pixel_format = pixel_format;
     bootinfo->video_width = screen_info->lfb_width;
     bootinfo->video_height = screen_info->lfb_height;

--- a/tests/test_iso_vesa_1024x768x32.sh
+++ b/tests/test_iso_vesa_1024x768x32.sh
@@ -42,15 +42,15 @@ check_no_warning
 echo "* Check a framebuffer video format was detected"
 grep -F "Video information:" $LOG || fail
 
-VIDEO_INFO=`grep -F -A 5 "Video information:" $LOG`
+VIDEO_INFO=`grep -F -A 4 "Video information:" $LOG`
 
 echo "$VIDEO_INFO" | grep -E 'type: framebuffer' || fail
 
 echo "* Check video resolution is 1024x768"
 echo "$VIDEO_INFO" | grep -E 'resolution: 1024x768' || fail
 
-echo "* Check video depth is 32 bits per pixel"
-echo "$VIDEO_INFO" | grep -E 'depth: 32' || fail
+echo "* Check pixel format is BGRA8888"
+echo "$VIDEO_INFO" | grep -E 'pixel format: BGRA8888' || fail
 
 echo "* Check framebuffer is initialized with resolution 1024x768"
 grep -F "Initializing video framebuffer for resolution 1024x768." $LOG || fail

--- a/tests/test_iso_vesa_1920x1080x32.sh
+++ b/tests/test_iso_vesa_1920x1080x32.sh
@@ -40,17 +40,20 @@ check_no_error
 echo "* Check a framebuffer video format was detected"
 grep -F "Video information:" $LOG || fail
 
-VIDEO_INFO=`grep -F -A 5 "Video information:" $LOG`
+VIDEO_INFO=`grep -F -A 4 "Video information:" $LOG`
 
 echo "$VIDEO_INFO" | grep -E 'type: framebuffer' || fail
 
 echo "* Check video resolution is 1920x1080"
 echo "$VIDEO_INFO" | grep -E 'resolution: 1920x1080' || fail
 
-echo "* Check video depth is 32 bits per pixel"
-echo "$VIDEO_INFO" | grep -E 'depth: 32' || fail
+echo "* Check pixel format is BGRA8888"
+echo "$VIDEO_INFO" | grep -E 'pixel format: BGRA8888' || fail
 
-echo "* Check framebuffer is not initialized because resolution is not supported"
-grep -F "warning: disabling video framebuffer because resolution is above 1024x768 supported maximum." $LOG || fail
+echo "* Check framebuffer is initialized with resolution 1920x1080"
+grep -F "Initializing video framebuffer for resolution 1920x1080." $LOG || fail
+
+echo "* Check console is initialized with size 240x67"
+grep -F "Initializing console with size 240x67." $LOG || fail
 
 check_reboot

--- a/tests/test_iso_vesa_640x480x32.sh
+++ b/tests/test_iso_vesa_640x480x32.sh
@@ -42,15 +42,15 @@ check_no_warning
 echo "* Check a framebuffer video format was detected"
 grep -F "Video information:" $LOG || fail
 
-VIDEO_INFO=`grep -F -A 5 "Video information:" $LOG`
+VIDEO_INFO=`grep -F -A 4 "Video information:" $LOG`
 
 echo "$VIDEO_INFO" | grep -E 'type: framebuffer' || fail
 
 echo "* Check video resolution is 640x480"
 echo "$VIDEO_INFO" | grep -E 'resolution: 640x480' || fail
 
-echo "* Check video depth is 32 bits per pixel"
-echo "$VIDEO_INFO" | grep -E 'depth: 32' || fail
+echo "* Check pixel format is BGRA8888"
+echo "$VIDEO_INFO" | grep -E 'pixel format: BGRA8888' || fail
 
 echo "* Check framebuffer is initialized with resolution 640x480"
 grep -F "Initializing video framebuffer for resolution 640x480." $LOG || fail


### PR DESCRIPTION
Remove the pixel backbuffer from the video framebuffer console implementation: now that the framebuffer is mapped with write-combining memory type, the backbuffer is no longer as critical to performance and it's simpler not to have to manage this memory.

This change eliminates the 1024x768 resolution limit. The limiting factor is now the framebuffer size which, at ~128MB, should allow up to 8K resolutions.