### PR TITLE
Update Github Actions dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     # is down. Keeping this step first lets the workflow fail faster. The next
     # step, installing the dependencies, is about 60% of the workflow total run
     # time.
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
       run: make testapp
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: artifact-${{ matrix.cc }}
         path: |


### PR DESCRIPTION
* Update `actions/checkout` from v6 to v7.
* Update `actions/upload-artifact` from v4 to v7.

The latter is the important one because v4 still targets Node.js 20, which is deprecated. This causes warnings when the workflow runs.